### PR TITLE
Fix ignoreSubdomain functionality

### DIFF
--- a/js/lib/parseUrl.js
+++ b/js/lib/parseUrl.js
@@ -45,7 +45,7 @@ function processURL(URL, ignoreProtocol, ignoreSubdomain, ignorePath, ignorePort
         baseHost = host;
     }
     else {
-        var result = host.match(/[^./]+\.[^./]+$/);
+        var result = host.match(/[^./]+\.[^./]+$/); // catch the two last parts, it's de hostname and the tld
         var TLDlength = 0;
         if(result){
             TLDlength = result[0].length;
@@ -61,7 +61,7 @@ function processURL(URL, ignoreProtocol, ignoreSubdomain, ignorePath, ignorePort
         returnURL += host;
     }
     else {
-        returnURL += baseHost;
+        returnURL += result[0];//return the hostname and the tld of the website if ignoreSubdomain is check
     }
     if (ignorePort) {
         returnURL = returnURL.replace(':' + port, "");

--- a/js/lib/parseUrl.js
+++ b/js/lib/parseUrl.js
@@ -46,12 +46,7 @@ function processURL(URL, ignoreProtocol, ignoreSubdomain, ignorePath, ignorePort
     }
     else {
         var result = host.match(/[^./]+\.[^./]+$/); // catch the two last parts, it's de hostname and the tld
-        var TLDlength = 0;
-        if(result){
-            TLDlength = result[0].length;
-        }
-
-        baseHost = splittedURL.slice(-TLDlength - 1).join(".");
+        baseHost=result[0];
     }
     var returnURL = "";
     if (!ignoreProtocol) {
@@ -61,7 +56,7 @@ function processURL(URL, ignoreProtocol, ignoreSubdomain, ignorePath, ignorePort
         returnURL += host;
     }
     else {
-        returnURL += result[0];//return the hostname and the tld of the website if ignoreSubdomain is check
+        returnURL += baseHost;//return the hostname and the tld of the website if ignoreSubdomain is check
     }
     if (ignorePort) {
         returnURL = returnURL.replace(':' + port, "");


### PR DESCRIPTION
Return the hostname and the tld if ignoreSubdomain is check.
The regex will catch the hostname and tld, all subdomain will be ignored. This regex may broke passman on websites reach with direct ip address.