### PR TITLE
Add notifications.js in the list of scripts loaded in browser_action

### DIFF
--- a/html/browser_action/browser_action.html
+++ b/html/browser_action/browser_action.html
@@ -15,6 +15,7 @@
         <script src="/js/lib/API/cookies.js"></script>
         <script src="/js/lib/API/extension.js"></script>
         <script src="/js/lib/API/i18n.js"></script>
+        <script src="/js/lib/API/notifications.js"></script>
         <script src="/js/lib/sharingAcl.js"></script>
         <script src="/js/lib/otp.js"></script>
         <script src="/js/lib/font-awesome.js"></script>


### PR DESCRIPTION
fixes #108 

API.notification was not loaded here https://github.com/nextcloud/passman-webextension/blob/master/js/lib/api.js#L224. 

