### PR TITLE
Fixing border line on left and improving sidebar transition

### DIFF
--- a/css/browser_action.css
+++ b/css/browser_action.css
@@ -555,12 +555,12 @@ body.toggled {
   transition: all 0.250s ease; }
 
 #sidebar-wrapper {
-  z-index: 1000;
+  z-index: 10000;
   position: fixed;
   left: 250px;
   width: 0;
   height: 100%;
-  margin-left: -250px;
+  margin-left: -251px;
   overflow: hidden;
   background: #fff;
   -webkit-transition: all 0.250s ease;
@@ -584,8 +584,7 @@ body.toggled {
   margin-right: -250px;
   /*  width: calc(100% - 250px);*/ }
 
-.ng-hide {
-  display: none; }
+
 
 /* Sidebar Styles */
 .sidebar-nav {
@@ -648,11 +647,18 @@ body.toggled {
 .menuToggler {
   position: fixed;
   background-color: rgba(0, 0, 0, 0.6);
-  width: calc(100% - 250px);
+  width: 100%;
   height: 100%;
-  z-index: 9999999;
+  z-index: 1000;
   right: 0;
-  top: 0; }
+  top: 0;
+  visibility: visible;
+  opacity: 1;
+  transition: visibility 250ms, opacity 250ms ease;}
+
+.ng-hide {
+  visibility: hidden;
+  opacity: 0;}
 
 .edit_credential {
   padding-top: 30px;


### PR DESCRIPTION
* Moved sidebar 1px to the left so that its right border would not creep into the view when not in use. See screenshot below to see it on the left side of the widget.
<img width="464" alt="screen shot 2017-08-01 at 14 50 24" src="https://user-images.githubusercontent.com/5390864/28841459-010657b6-7703-11e7-99ed-054010928613.png">

* Changed **ng-hide** to use visibility to be able add transitions to the **menuToggler** shadow coming in. **Note: First commit to this database so I'm not sure if ng-hide is being used in other places. If so then my changes break others**
* Made **menuToggler** fill 100% so that the sidebar wouldn't have a clear background while sliding in
* Changed z-indes values so that **menuToggler** would be under sidebar

How the changes to the sidebar look: 
![kapture 2017-08-01 at 21 14 06](https://user-images.githubusercontent.com/5390864/28841551-5604be56-7703-11e7-9fec-fd2de203d637.gif)
