### PR TITLE
Fix mismatch when it is website root

### DIFF
--- a/js/background/service/background.js
+++ b/js/background/service/background.js
@@ -267,7 +267,7 @@ var background = (function () {
             }
             credential_url = processURL(credential_url, _self.settings.ignoreProtocol, _self.settings.ignoreSubdomain, _self.settings.ignorePath, _self.settings.ignorePort);
             if (credential_url) {
-                if (credential_url.indexOf(url) !== -1) {
+                if (credential_url.split("\n").indexOf(url) !== -1) {
                     found_list.push(local_credentials[i]);
                 }
             }


### PR DESCRIPTION
There was one issue when we have a credential for the url: https://example.com and https://example.com/path
If you go to the root of the website (https://example.com) we will see the two credentials because credential_url is a string and not a array. The indexOf function doesn't return exact match for string.