### PR TITLE
Fix issue with ignoresite by processURL of the website

### DIFF
--- a/js/background/inject/inject.js
+++ b/js/background/inject/inject.js
@@ -15,7 +15,8 @@ $j(document).ready(function () {
     var _this = this;
     Array.prototype.findUrl = function (match) {
         return this.filter(function (item) {
-            return typeof item === 'string' && item.indexOf(match) > -1;
+            var matchParse = processURL(match, false, false, true, false);
+            return typeof item === 'string' && item.indexOf(matchParse) > -1;
         });
     };
 

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,8 @@
         "/js/lib/jQuerytoObject.js",
         "/js/lib/findForm.js",
         "/js/lib/parseUrl.js",
+        "/js/lib/parseTLD.js",
+        "/js/lib/data/tlds.js",
         "/js/lib/domchanged.js",
         "/js/background/inject/inject.js"
       ],


### PR DESCRIPTION
I had also the issue #167.
When you had the url to the ignoresite list you use the function processURL(url, false, false, true, false);
So when you compare the current website with the website in ignorelist in doesn't match really often because of the url path.
I use the processURL with the same parameter to correct this issue.
It seems to work on the tests I have done.