### PR TITLE
Add id / name based auto filling.

### DIFF
--- a/js/background/inject/inject.js
+++ b/js/background/inject/inject.js
@@ -60,9 +60,7 @@ $j(document).ready(function () {
 		try{
 			/* do we have custom_fields for this entry */
 			if(login.hasOwnProperty('custom_fields')&&login.custom_fields.length){
-				/* yes we do */
-				customfields=login.custom_fields;
-				/* iterate over all the custom_fields values */
+				/* yes we do, iterate over all the custom_fields values */
 				for(var i=0,len=login.custom_fields.length;i<len;i++){
 					/* does this custom field label begin with a hash? */
 					if(customfieldpattern.test(login.custom_fields[i].label)){

--- a/js/background/inject/inject.js
+++ b/js/background/inject/inject.js
@@ -76,7 +76,7 @@ $j(document).ready(function () {
 							element=false;
 						}
 						/* if we have an element and it is type text, number or password, lets auto fill it */
-						if(element&&(element[0].type=='text'||element[0].type=='number'||element[0].type=='password')){
+						if(element&&(element[0].type==='text'||element[0].type==='number'||element[0].type==='password')){
 							element.val(login.custom_fields[i].value);
 						}
 					}

--- a/js/background/inject/inject.js
+++ b/js/background/inject/inject.js
@@ -51,7 +51,6 @@ $j(document).ready(function () {
     _this.enterLoginDetails = enterLoginDetails;
 
     function enterCustomFields(login,settings) {
-		var customfields;
 		var customfieldpattern=/^\#(.*)$/;
 		var elementid;
 		var element=false;


### PR DESCRIPTION
Adds id / name based element auto filling. Custom fields that have a label that starts with a hash (#) are automatically searched for in the page and if found, are auto filled.

Fixes #138 