### PR TITLE
Implement command api. Fixes #181

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -50,6 +50,16 @@
     "default_title": "Passman",
     "default_popup": "/html/browser_action/browser_action.html"
   },
+  "commands":{
+    "_execute_browser_action": {
+      "suggested_key": {
+        "windows": "Alt+Down Arrow",
+        "mac": "Alt+Down Arrow",
+        "chromeos": "Alt+Down Arrow",
+        "linux": "Alt+Down Arrow"
+      }
+    }
+  },
   "permissions": [
     "*://*/*",
     "notifications",


### PR DESCRIPTION
Goto chrome://extensions/configureCommands to configure the shortcut key.
Default: Alt+Down Arrow
Signed-off-by: brantje <brantje@gmail.com>