### PR TITLE
Use custom fields to look for label content

### DIFF
--- a/js/background/inject/inject.js
+++ b/js/background/inject/inject.js
@@ -65,20 +65,11 @@ $j(document).ready(function () {
 					if(customFieldPattern.test(login.custom_fields[i].label)){
 						/* set variable elementid to whatever element we are trying to auto fill */
 						elementId=customFieldPattern.exec(login.custom_fields[i].label)[1];
-						/* check to see if element id exist */
-						if($j('#'+elementId).length){
-							element=$j('#'+elementId);
-						}
-						else if($j('input[name$="'+elementId+'"]').length){ /* maybe element name exist */
-							element=$j('input[name$="'+elementId+'"]');
-						}
-						else{ /* neither element id or name exist */
-							element=false;
-						}
-						/* if we have an element and it is type text, number or password, lets auto fill it */
-						if(element&&(element[0].type==='text'||element[0].type==='number'||element[0].type==='password')){
-							element.val(login.custom_fields[i].value);
-						}
+						enterCustomFieldElement(elementId, login.custom_fields[i].value);
+					}
+					else if ($j('label[for]:contains(' + login.custom_fields[i].label + ')').length) {
+						elementId=$j('label[for]:contains(' + login.custom_fields[i].label + ')').attr('for');
+						enterCustomFieldElement(elementId, login.custom_fields[i].value);
 					}
 				}
 			}
@@ -90,6 +81,23 @@ $j(document).ready(function () {
 		}
 	}
     
+    function enterCustomFieldElement(elementId, value) {
+    	/* check to see if element id exist */
+	if($j('#'+elementId).length){
+		element=$j('#'+elementId);
+	}
+	else if($j('input[name$="'+elementId+'"]').length){ /* maybe element name exist */
+		element=$j('input[name$="'+elementId+'"]');
+	}
+	else{ /* neither element id or name exist */
+		element=false;
+	}
+	/* if we have an element and it is type text, number or password, lets auto fill it */
+	if(element&&(element[0].type==='text'||element[0].type==='number'||element[0].type==='password')){
+		element.val(value);
+	}
+    }
+	
     function submitLoginForm(username) {
         if (!activeForm) {
             // @TODO detect login form on the current page


### PR DESCRIPTION
If custom field label doesn't start with #, look for label with for attribute and text content matching custom field label, and use for attribute to look for input field.

I tried to use custom fields for this web:
http://www.ruralvia.com/teruel/

When you click on "Acceso ruralvia" it displays 3 field login. I setup custom field with id for third input, but it works for few days and then stop working, because id and name are different.