### PR TITLE
Removed unexpected properties from manifest.json.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,9 +14,6 @@
     "64": "icons/icon64.png",
     "128": "icons/icon128.png"
   },
-  "externally_connectable": {
-    "ids": []
-  },
   "background": {
     "scripts": [
       "/js/vendor/jquery/jquery.js",
@@ -77,7 +74,6 @@
         "https://*/*"
       ],
       "all_frames": true,
-      "jsBuild": [],
       "js": [
         "/js/lib/promise.js",
         "/js/vendor/sjcl/sjcl.js",


### PR DESCRIPTION
I've fixed manifest.json to remove warnings in Firefox:

![grafik](https://github.com/nextcloud/passman-webextension/assets/22312491/c1140255-d855-4bf8-8533-a6165518ed21)
