### PR TITLE
Fix: Extension lock not enforced - search still accessible

### DIFF
--- a/js/ui/popup/controllers/search.js
+++ b/js/ui/popup/controllers/search.js
@@ -36,7 +36,27 @@
         .controller('SearchCtrl', ['$scope', function ($scope) {
             $scope.found_credentials = false;
             $scope.searchText = '';
+            $scope.isLocked = false;
+
+            // Check if extension is locked before any operation
+            API.runtime.sendMessage(API.runtime.id, {
+                'method': 'getVaultSettings'
+            }).then(function (settings) {
+                if (!settings || !settings.unlocked) {
+                    $scope.isLocked = true;
+                    window.location = '#!/locked';
+                    $scope.$apply();
+                }
+            }).catch(function () {
+                $scope.isLocked = true;
+                window.location = '#!/locked';
+            });
+
             $scope.search = function () {
+                if ($scope.isLocked) {
+                    window.location = '#!/locked';
+                    return;
+                }
                 API.runtime.sendMessage(API.runtime.id, {
                     'method': 'searchCredential',
                     args: $scope.searchText


### PR DESCRIPTION
## Fix for Bounty Issue #250

### Problem
When the browser extension is locked, users can still access the search functionality and view passwords without unlocking first.

### Solution
Added lock state check in SearchCtrl:
1. Check if extension is locked before executing search
2. Redirect to locked page if locked
3. Prevent search execution when locked

### Files Changed
- `js/ui/popup/controllers/search.js` - Added lock check

### Testing
- Extension now properly redirects to locked page when attempting to search while locked
- Search functionality is disabled when extension is locked

### Bounty
This fix addresses issue #250 which has a $25 bounty attached.

---
*This PR was created by OpenClaw ClawTeam*