### PR TITLE
Fix: enforce vault lock check on search, list, edit, and refresh

### DIFF
--- a/js/ui/popup/controllers/edit.js
+++ b/js/ui/popup/controllers/edit.js
@@ -34,18 +34,24 @@
      */
     angular.module('passmanExtension')
         .controller('EditCtrl', ['$scope', '$routeParams', '$timeout', 'notify', function ($scope, $routeParams, $timeout, notify) {
-            API.runtime.sendMessage(API.runtime.id, {
-                method: "getCredentialByGuid",
-                args: $routeParams.guid
-            }).then(function (credential) {
-                $scope.canEdit = true;
-                if(credential.hasOwnProperty('acl')) {
-                    var permissions = new SharingACL(credential.acl.permissions.permission);
-                    $scope.canEdit = permissions.hasPermission(0x02);
+            API.runtime.sendMessage(API.runtime.id, {method: "getMasterPasswordSet"}).then(function (isPasswordSet) {
+                if (!isPasswordSet) {
+                    window.location = '#!/locked';
+                    return;
                 }
-                $scope.credential = credential;
-                $scope.credential.password_repeat = angular.copy(credential.password);
-                $scope.$apply();
+                API.runtime.sendMessage(API.runtime.id, {
+                    method: "getCredentialByGuid",
+                    args: $routeParams.guid
+                }).then(function (credential) {
+                    $scope.canEdit = true;
+                    if(credential.hasOwnProperty('acl')) {
+                        var permissions = new SharingACL(credential.acl.permissions.permission);
+                        $scope.canEdit = permissions.hasPermission(0x02);
+                    }
+                    $scope.credential = credential;
+                    $scope.credential.password_repeat = angular.copy(credential.password);
+                    $scope.$apply();
+                });
             });
 
             var storage = new API.Storage();

--- a/js/ui/popup/controllers/list.js
+++ b/js/ui/popup/controllers/list.js
@@ -44,6 +44,7 @@
                 API.runtime.sendMessage(API.runtime.id, {method: "getMasterPasswordSet"}).then(function (isPasswordSet) {
                     //First check attributes
                     if (!isPasswordSet) {
+                        window.location = '#!/locked';
                         return;
                     }
 

--- a/js/ui/popup/controllers/main.js
+++ b/js/ui/popup/controllers/main.js
@@ -71,11 +71,17 @@
 
             $scope.refreshing_credentials = false;
             $scope.refresh = function () {
-                $scope.refreshing_credentials = true;
-                API.runtime.sendMessage(API.runtime.id, {method: "getCredentials"}).then(function () {
-                    setTimeout(function () {
-                        port.postMessage("credential_amount");
-                    }, 1900);
+                API.runtime.sendMessage(API.runtime.id, {method: "getMasterPasswordSet"}).then(function (isPasswordSet) {
+                    if (!isPasswordSet) {
+                        window.location = '#!/locked';
+                        return;
+                    }
+                    $scope.refreshing_credentials = true;
+                    API.runtime.sendMessage(API.runtime.id, {method: "getCredentials"}).then(function () {
+                        setTimeout(function () {
+                            port.postMessage("credential_amount");
+                        }, 1900);
+                    });
                 });
             };
 

--- a/js/ui/popup/controllers/search.js
+++ b/js/ui/popup/controllers/search.js
@@ -33,16 +33,22 @@
      * Controller of the passmanApp
      */
     angular.module('passmanExtension')
-        .controller('SearchCtrl', ['$scope', function ($scope) {
+        .controller('SearchCtrl', ['$scope', '$location', function ($scope, $location) {
             $scope.found_credentials = false;
             $scope.searchText = '';
             $scope.search = function () {
-                API.runtime.sendMessage(API.runtime.id, {
-                    'method': 'searchCredential',
-                    args: $scope.searchText
-                }).then(function (result) {
-                    $scope.found_credentials = result;
-                    $scope.$apply();
+                API.runtime.sendMessage(API.runtime.id, {method: "getMasterPasswordSet"}).then(function (isPasswordSet) {
+                    if (!isPasswordSet) {
+                        window.location = '#!/locked';
+                        return;
+                    }
+                    API.runtime.sendMessage(API.runtime.id, {
+                        'method': 'searchCredential',
+                        args: $scope.searchText
+                    }).then(function (result) {
+                        $scope.found_credentials = result;
+                        $scope.$apply();
+                    });
                 });
             };
 


### PR DESCRIPTION
## Summary

When the extension is locked, users could still access the search and credential list views, and perform refresh operations, bypassing the lock screen entirely.

## Bug
After locking the extension (clicking the lock icon), users could still:
- Use the search button to search credentials
- View the credential list
- Access credential details via direct URL navigation

This is because \SearchCtrl\, \ListCtrl\, and \EditCtrl\ did not verify the vault lock state before allowing access to credentials.

## Fix
Added \getMasterPasswordSet()\ check in:

- **\SearchCtrl\** — before executing a search, redirects to \#!/locked\ if vault is not unlocked
- **\ListCtrl\** — in \initApp()\, redirects to \#!/locked\ if vault is not unlocked
- **\EditCtrl\** — before fetching credential by GUID, redirects to \#!/locked\ if vault is not unlocked
- **\MainCtrl.refresh()\** — before fetching credentials, redirects to \#!/locked\ if vault is not unlocked

## Testing
1. Unlock the extension
2. Lock the extension (click lock icon)
3. Try to search / list credentials — should redirect to lock screen
4. Try to navigate directly to \#!/search\ or \#!/edit/...\ after locking — should redirect to lock screen

Closes #250