### PR TITLE
set custom CSP so HTTP server connections work as expected

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
             "gecko": {
                 "id": "{ed412846-94d6-4a82-88bd-58b83e43f06d}"
             }
+        },
+        content_security_policy: {
+            extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';"
         }
     },
     vite: () => ({


### PR DESCRIPTION
[Firefox's default MV3 CSP](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#default_content_security_policy) includes upgrade-insecure-requests, which silently rewrites http:// fetches to https://. So now we are explicitely using [Chrome's default MV3 CSP](https://developer.chrome.com/docs/extensions/reference/manifest/content-security-policy#extension_pages_policy) that matches our purpose.

closes #374