### PR TITLE
Add in-memory offline cache backend as alternative to the default IndexedDB solution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Type check
         run: bun run check-errors
 
+      - name: Test
+        run: bun run test
+
       - name: Build Chrome extension
         if: github.event_name == 'pull_request'
         run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@binsky/melt": "^0.42.0",
-        "@binsky/passman-client-ts": "^0.3.1",
+        "@binsky/passman-client-ts": "^0.3.2",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
         "@stylistic/eslint-plugin-ts": "^4.4.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -107,7 +107,7 @@
 
     "@binsky/melt": ["@binsky/melt@0.42.0", "", { "dependencies": { "@floating-ui/dom": "^1.6.13", "dequal": "^2.0.3", "focus-trap": "^7.6.5", "jest-axe": "^9.0.0", "runed": "^0.23.3" }, "peerDependencies": { "svelte": "^5.30.1" } }, "sha512-Ze8wTBchAFZF7C3YEciygIiGk9K+bPcVgwiodrNITxMt+d239+8VF+5Sr8Osohu5fJkU89pV4wzFfGbRUggeZg=="],
 
-    "@binsky/passman-client-ts": ["@binsky/passman-client-ts@0.3.1", "", { "dependencies": { "@types/html-escaper": "^3.0.2", "@types/node-forge": "^1.3.11", "@zxcvbn-ts/core": "^3.0.4", "@zxcvbn-ts/language-common": "^3.0.4", "@zxcvbn-ts/language-en": "^3.0.2", "html-escaper": "^3.0.3", "idb": "^8.0.3", "js-base64": "^3.7.7", "node-forge": "^1.3.1", "otpauth": "^9.2.2", "qrcode-generator": "^1.4.4", "qrcode-parser": "^2.1.3", "sjcl": "^1.0.8" } }, "sha512-LzFPbQ5hizhDL4FBROTsfhYjEqffmYvDv54G356TqOkr4j+Nw/hUmhYkvajyS6JYTZIMNASNLIuk2GQ9kVMkjg=="],
+    "@binsky/passman-client-ts": ["@binsky/passman-client-ts@0.3.2", "", { "dependencies": { "@types/html-escaper": "^3.0.4", "@types/node-forge": "^1.3.14", "@zxcvbn-ts/core": "^3.0.4", "@zxcvbn-ts/language-common": "^3.0.4", "@zxcvbn-ts/language-en": "^3.0.2", "html-escaper": "^3.0.3", "idb": "^8.0.3", "js-base64": "^3.9.2", "node-forge": "^1.4.0", "otpauth": "^9.5.1", "qrcode-generator": "^1.5.2", "qrcode-parser": "^2.1.3", "sjcl": "^1.0.9" } }, "sha512-T32FGVZjSXW332a/AGD36fIQcv3ZUxY9gECzkGJx5y1Q1biGtRqMjdvXWfjbMZ3tOj188dh0EK7FPu5wpU+01Q=="],
 
     "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.8", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw=="],
 
@@ -215,7 +215,7 @@
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 
-    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -851,7 +851,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
+    "js-base64": ["js-base64@3.9.2", "", {}, "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA=="],
 
     "js-sha512": ["js-sha512@0.9.0", "", {}, "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg=="],
 
@@ -1009,7 +1009,7 @@
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
-    "node-forge": ["node-forge@1.3.1", "", {}, "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="],
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "node-notifier": ["node-notifier@10.0.1", "", { "dependencies": { "growly": "^1.3.0", "is-wsl": "^2.2.0", "semver": "^7.3.5", "shellwords": "^0.1.1", "uuid": "^8.3.2", "which": "^2.0.2" } }, "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ=="],
 
@@ -1041,7 +1041,7 @@
 
     "os-shim": ["os-shim@0.1.3", "", {}, "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A=="],
 
-    "otpauth": ["otpauth@9.4.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-+iVvys36CFsyXEqfNftQm1II7SW23W1wx9RwNk0Cd97lbvorqAhBDksb/0bYry087QMxjiuBS0wokdoZ0iUeAw=="],
+    "otpauth": ["otpauth@9.5.1", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -1209,7 +1209,7 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "sjcl": ["sjcl@1.0.8", "", {}, "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ=="],
+    "sjcl": ["sjcl@1.0.9", "", {}, "sha512-dWM71tkSHxe7zEZj0/COjtJdmErIxp7UMp8a6D4xx8dTTtJLc4lFL+HAX8s6lvASyQQ2iYMHwa7rhhQq7MT5MA=="],
 
     "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
@@ -1404,6 +1404,8 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@devicefarmer/adbkit/debug": ["debug@4.3.7", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ=="],
+
+    "@devicefarmer/adbkit/node-forge": ["node-forge@1.3.1", "", {}, "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@binsky/melt": "^0.42.0",
-        "@binsky/passman-client-ts": "^0.3.0",
+        "@binsky/passman-client-ts": "^0.3.1",
         "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
         "@stylistic/eslint-plugin-ts": "^4.4.1",
         "@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -33,7 +33,7 @@
         "autoprefixer": "^10.5.4",
         "eslint-plugin-svelte": "^3.22.0",
         "eslint-plugin-tailwindcss": "^3.18.3",
-        "postcss": "^8.5.23",
+        "postcss": "^8.5.25",
         "postcss-rem-to-pixel": "^4.1.2",
         "prettier": "^3.9.6",
         "prettier-plugin-svelte": "^3.5.2",

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/vite": "^4.3.3",
         "@tsconfig/svelte": "^5.0.8",
+        "@types/bun": "^1.3.14",
         "@types/node": "^22.20.1",
         "@types/pouchdb": "^6.4.2",
         "@types/pouchdb-adapter-memory": "^6.1.6",
@@ -348,6 +349,8 @@
 
     "@tsconfig/svelte": ["@tsconfig/svelte@5.0.8", "", {}, "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -509,6 +512,8 @@
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@binsky/melt": "^0.42.0",
-    "@binsky/passman-client-ts": "^0.3.1",
+    "@binsky/passman-client-ts": "^0.3.2",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@stylistic/eslint-plugin-ts": "^4.4.1",
     "@sveltejs/vite-plugin-svelte": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "zip:firefox": "wxt zip -b firefox --mv3",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check-errors": "svelte-check --tsconfig ./tsconfig.json --threshold error",
+    "test": "bun test src/",
     "fixture:legacy-settings": "bun scripts/build-legacy-settings-fixture.ts",
     "postinstall": "wxt prepare"
   },
@@ -34,6 +35,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/vite": "^4.3.3",
     "@tsconfig/svelte": "^5.0.8",
+    "@types/bun": "^1.3.14",
     "@types/node": "^22.20.1",
     "@types/pouchdb": "^6.4.2",
     "@types/pouchdb-adapter-memory": "^6.1.6",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1107,6 +1107,46 @@
     "message": "Failed to clear offline cache",
     "description": "Error toast after failing to clear offline cache"
   },
+  "offline_cache_storage_backend": {
+    "message": "Cache storage",
+    "description": "Label for offline cache backend select (IndexedDB vs in-memory)"
+  },
+  "offline_cache_storage_backend_description": {
+    "message": "Where encrypted vault cache is kept. IndexedDB persists across restarts; in-memory is cleared when the extension background script restarts.",
+    "description": "Explains the two offline cache storage backends"
+  },
+  "offline_cache_storage_backend_indexeddb": {
+    "message": "IndexedDB (persistent)",
+    "description": "Offline cache backend option: native IndexedDB"
+  },
+  "offline_cache_storage_backend_memory": {
+    "message": "In-memory (session / time limited)",
+    "description": "Offline cache backend option: volatile in-memory model store (cleared when the extension background script restarts)"
+  },
+  "offline_cache_memory_mode_notice": {
+    "message": "Using in-memory cache. Cached vaults are lost when the extension background script restarts; they reload from the server when needed.",
+    "description": "Amber notice when effective offline cache backend is memory"
+  },
+  "offline_cache_forced_fallback_notice": {
+    "message": "Native IndexedDB is not available in this browser profile (for example Firefox with “Never remember history”). In-memory cache is used instead.",
+    "description": "Amber notice when IndexedDB was requested but blocked"
+  },
+  "offline_cache_size_memory_note": {
+    "message": "Size reflects the current session only.",
+    "description": "Footnote under cache size when using in-memory backend"
+  },
+  "offline_cache_indexeddb_unavailable_warning": {
+    "message": "IndexedDB is not available here, so in-memory cache stays active.",
+    "description": "Warning toast when user chose IndexedDB but probe forced memory"
+  },
+  "offline_cache_quota_notice": {
+    "message": "Offline cache storage is full (quota exceeded). Free space or clear the offline cache in Extended settings.",
+    "description": "Pinned toast when IndexedDB quota is exceeded"
+  },
+  "setup_offline_cache_fallback_notice": {
+    "message": "This browser profile cannot use IndexedDB (for example Firefox with “Never remember history”). Passman will use an in-memory cache that is cleared when the extension background script restarts.",
+    "description": "Amber banner during setup when native IndexedDB is unavailable"
+  },
   "server_connections": {
     "message": "Saved servers",
     "description": "Heading for the Nextcloud connection directory list"

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -31,6 +31,7 @@ import './messages/clearPendingDoorhangerCredential';
 import './messages/updateCredentialForDoorhanger';
 import './messages/getDoorhangerSettings';
 import './messages/probeServerConnection';
+import './messages/recreateOfflineCachePersistence';
 import { executeOnMessageListenerRegistration } from "@/entrypoints/background/messaging";
 import { DoorhangerPendingCredentialService } from "@/services/backend/DoorhangerPendingCredentialService";
 

--- a/src/entrypoints/background/messages/addNewServerConnection.ts
+++ b/src/entrypoints/background/messages/addNewServerConnection.ts
@@ -53,7 +53,7 @@ onMessage('addNewServerConnection', async (message) => {
             backendAppId: rawServerData.backendAppId ?? 'passman', // default to passman if not provided (to prevent 99% useless attempts to probe other apps for now)
         };
 
-        const persistence = CustomStorageService.getExtensionPassmanClientPersistenceService();
+        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         let backendPassmanClient = await PassmanClientService.getBackendPassmanClient();
 
         if (backendPassmanClient) {

--- a/src/entrypoints/background/messages/addNewServerConnection.ts
+++ b/src/entrypoints/background/messages/addNewServerConnection.ts
@@ -4,7 +4,7 @@ import type {
     NextcloudServerInfoInterface
 } from "@binsky/passman-client-ts/lib/Interfaces/NextcloudServer/NextcloudServerInfoInterface";
 import { BackendPassmanClient } from "~/lib/BackendPassmanClient";
-import CustomStorageService from "~/services/CustomStorageService";
+import OfflineCachePersistenceService from "~/services/OfflineCachePersistenceService";
 import { PassmanServerConnection } from "@binsky/passman-client-ts/lib/Model/PassmanServerConnection";
 import { onMessage } from '../messaging';
 import { i18n } from "~/lib/i18n";
@@ -53,7 +53,7 @@ onMessage('addNewServerConnection', async (message) => {
             backendAppId: rawServerData.backendAppId ?? 'passman', // default to passman if not provided (to prevent 99% useless attempts to probe other apps for now)
         };
 
-        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+        const persistence = await OfflineCachePersistenceService.get();
         let backendPassmanClient = await PassmanClientService.getBackendPassmanClient();
 
         if (backendPassmanClient) {

--- a/src/entrypoints/background/messages/recreateOfflineCachePersistence.ts
+++ b/src/entrypoints/background/messages/recreateOfflineCachePersistence.ts
@@ -1,0 +1,41 @@
+import { onMessage } from "../messaging";
+import CustomStorageService from "~/services/CustomStorageService";
+import type { OfflineCacheStorageBackend } from "~/services/OfflineCacheStorageService";
+import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
+import { logger } from "~/services/ConsoleLoggingService";
+
+export interface RecreateOfflineCachePersistenceRequest {
+    preferred?: OfflineCacheStorageBackend;
+}
+
+export interface RecreateOfflineCachePersistenceResponse {
+    status: boolean;
+    effective: OfflineCacheStorageBackend;
+    forcedFallback: boolean;
+}
+
+/**
+ * Recreate the offline cache persistence service of the background SW script.
+ * Required since each, frontend (options/popup) and background SW, have their own CustomStorageService singleton.
+ * While this architecture is basically fine and avoids lots of synchronisation work through the message api when using IndexedDB cache backend,
+ * it does not work well with the in-memory cache backend (which exists duplicated in both realms).
+ * So we need this little overhead to definitively keep backend and frontend storage instance configurations perfectly in sync.
+ */
+onMessage("recreateOfflineCachePersistence", async (message) => {
+    try {
+        const preferred = message.data?.preferred;
+        await CustomStorageService.recreateExtensionPassmanClientPersistenceService(preferred);
+        return {
+            status: true,
+            effective: OfflineCacheStorageService.getEffective(),
+            forcedFallback: OfflineCacheStorageService.isForcedFallback(),
+        };
+    } catch (error) {
+        logger.error("[recreateOfflineCachePersistence]", error);
+        return {
+            status: false,
+            effective: OfflineCacheStorageService.getEffective(),
+            forcedFallback: OfflineCacheStorageService.isForcedFallback(),
+        };
+    }
+});

--- a/src/entrypoints/background/messages/recreateOfflineCachePersistence.ts
+++ b/src/entrypoints/background/messages/recreateOfflineCachePersistence.ts
@@ -1,7 +1,8 @@
 import { onMessage } from "../messaging";
-import CustomStorageService from "~/services/CustomStorageService";
+import OfflineCachePersistenceService from "~/services/OfflineCachePersistenceService";
 import type { OfflineCacheStorageBackend } from "~/services/OfflineCacheStorageService";
 import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
+import PassmanClientService from "~/services/PassmanClientService";
 import { logger } from "~/services/ConsoleLoggingService";
 
 export interface RecreateOfflineCachePersistenceRequest {
@@ -16,7 +17,7 @@ export interface RecreateOfflineCachePersistenceResponse {
 
 /**
  * Recreate the offline cache persistence service of the background SW script.
- * Required since each, frontend (options/popup) and background SW, have their own CustomStorageService singleton.
+ * Required since each, frontend (options/popup) and background SW, have their own OfflineCachePersistenceService singleton.
  * While this architecture is basically fine and avoids lots of synchronisation work through the message api when using IndexedDB cache backend,
  * it does not work well with the in-memory cache backend (which exists duplicated in both realms).
  * So we need this little overhead to definitively keep backend and frontend storage instance configurations perfectly in sync.
@@ -24,7 +25,8 @@ export interface RecreateOfflineCachePersistenceResponse {
 onMessage("recreateOfflineCachePersistence", async (message) => {
     try {
         const preferred = message.data?.preferred;
-        await CustomStorageService.recreateExtensionPassmanClientPersistenceService(preferred);
+        PassmanClientService.invalidatePassmanClients();
+        await OfflineCachePersistenceService.recreate(preferred);
         return {
             status: true,
             effective: OfflineCacheStorageService.getEffective(),

--- a/src/entrypoints/background/messages/unlockExtension.ts
+++ b/src/entrypoints/background/messages/unlockExtension.ts
@@ -1,7 +1,6 @@
 import ExtensionSettingsService, { ExtensionSettingsOptions } from "~/services/ExtensionSettingsService";
 import PassmanClientService from "~/services/PassmanClientService";
 import ExtensionUnlockService from "~/services/ExtensionUnlockService";
-import CustomStorageService from "~/services/CustomStorageService";
 import { onMessage } from '../messaging';
 import { logger } from "~/services/ConsoleLoggingService";
 
@@ -27,7 +26,6 @@ onMessage('unlockExtension', async (message) => {
 
         if (status && message.data.refreshAfterUnlock) {
             try {
-                await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
                 const backendPassmanClient = await PassmanClientService.getBackendPassmanClient();
                 logger.debug("backendPassmanClient", backendPassmanClient);
 

--- a/src/entrypoints/background/messages/unlockExtension.ts
+++ b/src/entrypoints/background/messages/unlockExtension.ts
@@ -1,6 +1,7 @@
 import ExtensionSettingsService, { ExtensionSettingsOptions } from "~/services/ExtensionSettingsService";
 import PassmanClientService from "~/services/PassmanClientService";
 import ExtensionUnlockService from "~/services/ExtensionUnlockService";
+import CustomStorageService from "~/services/CustomStorageService";
 import { onMessage } from '../messaging';
 import { logger } from "~/services/ConsoleLoggingService";
 
@@ -26,6 +27,7 @@ onMessage('unlockExtension', async (message) => {
 
         if (status && message.data.refreshAfterUnlock) {
             try {
+                await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
                 const backendPassmanClient = await PassmanClientService.getBackendPassmanClient();
                 logger.debug("backendPassmanClient", backendPassmanClient);
 

--- a/src/entrypoints/background/messaging.ts
+++ b/src/entrypoints/background/messaging.ts
@@ -73,6 +73,10 @@ import {
     ProbeServerConnectionRequest,
     ProbeServerConnectionResponse
 } from "@/entrypoints/background/messages/probeServerConnection";
+import {
+    RecreateOfflineCachePersistenceRequest,
+    RecreateOfflineCachePersistenceResponse
+} from "@/entrypoints/background/messages/recreateOfflineCachePersistence";
 
 interface ProtocolMap {
     ping(): PingResponse;
@@ -124,6 +128,8 @@ interface ProtocolMap {
     getDoorhangerSettings(): GetDoorhangerSettingsResponse;
 
     probeServerConnection(data: ProbeServerConnectionRequest): ProbeServerConnectionResponse;
+
+    recreateOfflineCachePersistence(data?: RecreateOfflineCachePersistenceRequest): RecreateOfflineCachePersistenceResponse;
 
     // content script
     [RemoteCallableFunctions.remoteFunctionCallMessageName](data: RemoteCallableFunctionMessagingRequest): boolean | null | void;

--- a/src/entrypoints/options/App.svelte
+++ b/src/entrypoints/options/App.svelte
@@ -10,9 +10,11 @@
   import { sendMessage } from "@/entrypoints/background/messaging";
   import { i18n } from "~/lib/i18n";
   import ConsoleLoggingService, { logger } from "~/services/ConsoleLoggingService";
+  import { flushOfflineCacheNotices } from "~/services/frontend/flushOfflineCacheNotices";
 
   onMount(async () => {
     void ConsoleLoggingService.refreshLogLevel();
+    void flushOfflineCacheNotices();
 
     sendMessage('getExtensionUnlockState').then((value) => {
       switch (value.status) {

--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -11,9 +11,11 @@
   import { sendMessage } from "@/entrypoints/background/messaging";
   import { i18n } from "~/lib/i18n";
   import ConsoleLoggingService, { logger } from "~/services/ConsoleLoggingService";
+  import { flushOfflineCacheNotices } from "~/services/frontend/flushOfflineCacheNotices";
 
   onMount(async () => {
     void ConsoleLoggingService.refreshLogLevel();
+    void flushOfflineCacheNotices();
 
     sendMessage('getExtensionUnlockState').then((value) => {
       // use locked as initial state; will be overridden by the actual state right after the switch

--- a/src/lib/NextcloudServerMessagingConnector.ts
+++ b/src/lib/NextcloudServerMessagingConnector.ts
@@ -5,8 +5,8 @@ import type { LoggingHandlerInterface } from "@binsky/passman-client-ts/lib/Inte
 import type {
     NextcloudServerInfoInterface
 } from "@binsky/passman-client-ts/lib/Interfaces/NextcloudServer/NextcloudServerInfoInterface";
+import type { PersistenceInterface } from "@binsky/passman-client-ts/lib/Interfaces/PersistenceInterface";
 import { NextcloudServer } from "@binsky/passman-client-ts/lib/Model/NextcloudServer";
-import CustomStorageService from "@/services/CustomStorageService";
 import { NextcloudServerMessagingConnectorService } from "@/services/NextcloudServerMessagingConnectorService";
 import PassmanClientService from "@/services/PassmanClientService";
 import { sendMessage } from "@/entrypoints/background/messaging";
@@ -19,10 +19,11 @@ export class NextcloudServerMessagingConnector extends NextcloudServer implement
      * Instead of directly executing fetch requests, request / response data will be transferred to the background service worker through the messaging api.
      * @param serverData
      * @param logger
+     * @param persistence
      * @throws ConfigurationError
      */
-    constructor(serverData: NextcloudServerInfoInterface, logger: LoggingHandlerInterface) {
-        super(serverData, logger, CustomStorageService.getExtensionPassmanClientPersistenceService());
+    constructor(serverData: NextcloudServerInfoInterface, logger: LoggingHandlerInterface, persistence: PersistenceInterface) {
+        super(serverData, logger, persistence);
     }
 
     private readonly handleConnectorJsonResponse = <T>(response: any, errorCallback: (response: Error) => void): T | void => {

--- a/src/services/CustomStorageService.ts
+++ b/src/services/CustomStorageService.ts
@@ -1,38 +1,18 @@
 import { Storage } from "@/lib/storage";
 import { SecureStorage } from "@/lib/secure-storage";
 import ExtensionUnlockService from "./ExtensionUnlockService";
-import ExtensionPassmanClientPersistenceService from "./ExtensionPassmanClientPersistenceService";
-import { customIndexedDBService as inMemoryOnlyIndexedDBService } from "./CustomIndexedDBService";
-import {
-    IndexedDbModelStore,
-    type IndexedDbModelStoreSizeEstimate,
-} from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
-import type { ModelStoreInterface } from "@binsky/passman-client-ts/lib/Interfaces/ModelStoreInterface";
-import OfflineCacheStorageService, {
-    type OfflineCacheStorageBackend,
-} from "~/services/OfflineCacheStorageService";
-import InMemoryModelStore from "~/services/InMemoryModelStore";
-import NotifyingModelStore from "~/services/NotifyingModelStore";
-import { logger } from "@/services/ConsoleLoggingService";
 
 // todo: empty atm, but we should use a namespace (may need a migration logic)
 export const DEFAULT_STORAGE_NAMESPACE = '';
 
-type OfflineModelStore = (IndexedDbModelStore | InMemoryModelStore) & ModelStoreInterface & {
-    estimateSize(): Promise<IndexedDbModelStoreSizeEstimate>;
-    clearDatabase(): Promise<void>;
-};
-
 /**
- * todo: I don't rellay like what this became. When touching the class again, think about a refactoring of all the storage classes and their interaction.
+ * Session / local / secure storage only.
+ * The offline-cache PassmanClient persistence lifecycle (model store, IndexedDB/in-memory backend) lives in {@link OfflineCachePersistenceService} instead.
  */
 export default class CustomStorageService {
     private static sessionStorage: Storage;
     private static unsafeLocalStorage: Storage;
     private static secureStorage?: SecureStorage;
-    private static extensionPersistenceService?: ExtensionPassmanClientPersistenceService;
-    private static offlineModelStore?: OfflineModelStore;
-    private static initInFlight: Promise<ExtensionPassmanClientPersistenceService> | null = null;
 
     public static getSessionStorage() {
         if (!this.sessionStorage) {
@@ -76,132 +56,5 @@ export default class CustomStorageService {
 
     public static async clearSessionStorage() {
         return this.getSessionStorage().clear();
-    }
-
-    private static async readPreferredOfflineCacheBackend(): Promise<OfflineCacheStorageBackend> {
-        try {
-            const { default: ExtensionSettingsService, ExtensionSettingsOptions } = await import(
-                "~/services/ExtensionSettingsService"
-            );
-            const value = await ExtensionSettingsService.getPartialExtensionSettings(
-                ExtensionSettingsOptions.offlineCacheStorageBackend,
-                true
-            );
-            if (value === "indexeddb" || value === "memory") {
-                return value;
-            }
-        } catch {
-            // SecureStorage may be locked; fall through to default
-        }
-        return OfflineCacheStorageService.DEFAULT_BACKEND;
-    }
-
-    private static async persistPreferredOfflineCacheBackend(
-        backend: OfflineCacheStorageBackend
-    ): Promise<void> {
-        try {
-            const { default: ExtensionSettingsService, ExtensionSettingsOptions } = await import(
-                "~/services/ExtensionSettingsService"
-            );
-            await ExtensionSettingsService.updatePartialExtensionSettings(
-                ExtensionSettingsOptions.offlineCacheStorageBackend,
-                backend
-            );
-        } catch (error) {
-            logger.warn(
-                "[CustomStorageService] Could not persist offlineCacheStorageBackend (SecureStorage locked?)",
-                error
-            );
-        }
-    }
-
-    private static createOfflineModelStore(effective: OfflineCacheStorageBackend): OfflineModelStore {
-        if (effective === "memory") {
-            return new InMemoryModelStore();
-        }
-        return new IndexedDbModelStore(
-            IndexedDbModelStore.DEFAULT_DB_NAME,
-            (reason) => {
-                logger.warn(
-                    `[CustomStorageService] Model store IndexedDB "${IndexedDbModelStore.DEFAULT_DB_NAME}" reopened after unexpected loss (${reason}). Offline cache will refill on next network fetch.`
-                );
-                inMemoryOnlyIndexedDBService.clear();
-            }
-        );
-    }
-
-    private static async buildExtensionPassmanClientPersistenceService(
-        preferred: OfflineCacheStorageBackend
-    ): Promise<ExtensionPassmanClientPersistenceService> {
-        const effective = await OfflineCacheStorageService.resolveEffectiveBackend(preferred);
-
-        if (OfflineCacheStorageService.isForcedFallback()) {
-            await this.persistPreferredOfflineCacheBackend("memory");
-        }
-
-        this.offlineModelStore = this.createOfflineModelStore(effective);
-        this.extensionPersistenceService = new ExtensionPassmanClientPersistenceService(
-            true,
-            new NotifyingModelStore(this.offlineModelStore),
-            inMemoryOnlyIndexedDBService
-        );
-        return this.extensionPersistenceService;
-    }
-
-    /**
-     * Probe/resolve offline-cache backend and create the PassmanClient persistence singleton.
-     */
-    public static async ensureExtensionPassmanClientPersistenceService(
-        preferred?: OfflineCacheStorageBackend
-    ): Promise<ExtensionPassmanClientPersistenceService> {
-        if (this.extensionPersistenceService) {
-            return this.extensionPersistenceService;
-        }
-        if (this.initInFlight) {
-            return this.initInFlight;
-        }
-
-        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
-        this.initInFlight = this.buildExtensionPassmanClientPersistenceService(resolvedPreferred);
-        try {
-            return await this.initInFlight;
-        } finally {
-            this.initInFlight = null;
-        }
-    }
-
-    /**
-     * Drop the current model store / persistence, invalidate PassmanClients, and rebuild for `preferred`.
-     */
-    public static async recreateExtensionPassmanClientPersistenceService(
-        preferred?: OfflineCacheStorageBackend
-    ): Promise<ExtensionPassmanClientPersistenceService> {
-        this.initInFlight = null;
-        this.extensionPersistenceService = undefined;
-        this.offlineModelStore = undefined;
-        inMemoryOnlyIndexedDBService.clear();
-
-        const { default: PassmanClientService } = await import("~/services/PassmanClientService");
-        PassmanClientService.invalidatePassmanClients();
-
-        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
-        return this.ensureExtensionPassmanClientPersistenceService(resolvedPreferred);
-    }
-
-    private static async getOfflineModelStore(): Promise<OfflineModelStore> {
-        await this.ensureExtensionPassmanClientPersistenceService();
-        if (!this.offlineModelStore) {
-            throw new Error("Offline model store was not initialized");
-        }
-        return this.offlineModelStore;
-    }
-
-    public static async estimateOfflineModelStoreSize(): Promise<IndexedDbModelStoreSizeEstimate> {
-        return (await this.getOfflineModelStore()).estimateSize();
-    }
-
-    public static async clearOfflineModelStore(): Promise<void> {
-        await (await this.getOfflineModelStore()).clearDatabase();
-        inMemoryOnlyIndexedDBService.clear();
     }
 }

--- a/src/services/CustomStorageService.ts
+++ b/src/services/CustomStorageService.ts
@@ -150,7 +150,6 @@ export default class CustomStorageService {
 
     /**
      * Probe/resolve offline-cache backend and create the PassmanClient persistence singleton.
-     * Must be awaited before {@link getExtensionPassmanClientPersistenceService}.
      */
     public static async ensureExtensionPassmanClientPersistenceService(
         preferred?: OfflineCacheStorageBackend
@@ -187,19 +186,6 @@ export default class CustomStorageService {
 
         const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
         return this.ensureExtensionPassmanClientPersistenceService(resolvedPreferred);
-    }
-
-    /**
-     * Persistence for PassmanClient: model store (+ optional decrypted-field cache).
-     * Call {@link ensureExtensionPassmanClientPersistenceService} first.
-     */
-    public static getExtensionPassmanClientPersistenceService() {
-        if (!this.extensionPersistenceService) {
-            throw new Error(
-                "CustomStorageService.ensureExtensionPassmanClientPersistenceService() must be awaited before getExtensionPassmanClientPersistenceService()"
-            );
-        }
-        return this.extensionPersistenceService;
     }
 
     private static async getOfflineModelStore(): Promise<OfflineModelStore> {

--- a/src/services/CustomStorageService.ts
+++ b/src/services/CustomStorageService.ts
@@ -7,17 +7,32 @@ import {
     IndexedDbModelStore,
     type IndexedDbModelStoreSizeEstimate,
 } from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
+import type { ModelStoreInterface } from "@binsky/passman-client-ts/lib/Interfaces/ModelStoreInterface";
+import OfflineCacheStorageService, {
+    type OfflineCacheStorageBackend,
+} from "~/services/OfflineCacheStorageService";
+import InMemoryModelStore from "~/services/InMemoryModelStore";
+import NotifyingModelStore from "~/services/NotifyingModelStore";
 import { logger } from "@/services/ConsoleLoggingService";
 
 // todo: empty atm, but we should use a namespace (may need a migration logic)
 export const DEFAULT_STORAGE_NAMESPACE = '';
 
+type OfflineModelStore = (IndexedDbModelStore | InMemoryModelStore) & ModelStoreInterface & {
+    estimateSize(): Promise<IndexedDbModelStoreSizeEstimate>;
+    clearDatabase(): Promise<void>;
+};
+
+/**
+ * todo: I don't rellay like what this became. When touching the class again, think about a refactoring of all the storage classes and their interaction.
+ */
 export default class CustomStorageService {
     private static sessionStorage: Storage;
     private static unsafeLocalStorage: Storage;
     private static secureStorage?: SecureStorage;
     private static extensionPersistenceService?: ExtensionPassmanClientPersistenceService;
-    private static modelStore?: IndexedDbModelStore;
+    private static offlineModelStore?: OfflineModelStore;
+    private static initInFlight: Promise<ExtensionPassmanClientPersistenceService> | null = null;
 
     public static getSessionStorage() {
         if (!this.sessionStorage) {
@@ -43,7 +58,6 @@ export default class CustomStorageService {
             this.secureStorage.setNamespace(DEFAULT_STORAGE_NAMESPACE);
         }
         if (!this.secureStorage.isPasswordSet) {
-            // set password (if possible) for fresh created or cached secureStorage instance without a password set
             const extensionUnlockPassword = await this.getSessionStorage().get(ExtensionUnlockService.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY);
             if (extensionUnlockPassword) {
                 this.secureStorage.setPassword(
@@ -64,51 +78,144 @@ export default class CustomStorageService {
         return this.getSessionStorage().clear();
     }
 
+    private static async readPreferredOfflineCacheBackend(): Promise<OfflineCacheStorageBackend> {
+        try {
+            const { default: ExtensionSettingsService, ExtensionSettingsOptions } = await import(
+                "~/services/ExtensionSettingsService"
+            );
+            const value = await ExtensionSettingsService.getPartialExtensionSettings(
+                ExtensionSettingsOptions.offlineCacheStorageBackend,
+                true
+            );
+            if (value === "indexeddb" || value === "memory") {
+                return value;
+            }
+        } catch {
+            // SecureStorage may be locked; fall through to default
+        }
+        return OfflineCacheStorageService.DEFAULT_BACKEND;
+    }
+
+    private static async persistPreferredOfflineCacheBackend(
+        backend: OfflineCacheStorageBackend
+    ): Promise<void> {
+        try {
+            const { default: ExtensionSettingsService, ExtensionSettingsOptions } = await import(
+                "~/services/ExtensionSettingsService"
+            );
+            await ExtensionSettingsService.updatePartialExtensionSettings(
+                ExtensionSettingsOptions.offlineCacheStorageBackend,
+                backend
+            );
+        } catch (error) {
+            logger.warn(
+                "[CustomStorageService] Could not persist offlineCacheStorageBackend (SecureStorage locked?)",
+                error
+            );
+        }
+    }
+
+    private static createOfflineModelStore(effective: OfflineCacheStorageBackend): OfflineModelStore {
+        if (effective === "memory") {
+            return new InMemoryModelStore();
+        }
+        return new IndexedDbModelStore(
+            IndexedDbModelStore.DEFAULT_DB_NAME,
+            (reason) => {
+                logger.warn(
+                    `[CustomStorageService] Model store IndexedDB "${IndexedDbModelStore.DEFAULT_DB_NAME}" reopened after unexpected loss (${reason}). Offline cache will refill on next network fetch.`
+                );
+                inMemoryOnlyIndexedDBService.clear();
+            }
+        );
+    }
+
+    private static async buildExtensionPassmanClientPersistenceService(
+        preferred: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        const effective = await OfflineCacheStorageService.resolveEffectiveBackend(preferred);
+
+        if (OfflineCacheStorageService.isForcedFallback()) {
+            await this.persistPreferredOfflineCacheBackend("memory");
+        }
+
+        this.offlineModelStore = this.createOfflineModelStore(effective);
+        this.extensionPersistenceService = new ExtensionPassmanClientPersistenceService(
+            true,
+            new NotifyingModelStore(this.offlineModelStore),
+            inMemoryOnlyIndexedDBService
+        );
+        return this.extensionPersistenceService;
+    }
+
     /**
-     * Persistence for PassmanClient: IndexedDB model store (+ optional decrypted-field cache).
-     * Reuses one instance so background and popup share the same store configuration.
+     * Probe/resolve offline-cache backend and create the PassmanClient persistence singleton.
+     * Must be awaited before {@link getExtensionPassmanClientPersistenceService}.
+     */
+    public static async ensureExtensionPassmanClientPersistenceService(
+        preferred?: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        if (this.extensionPersistenceService) {
+            return this.extensionPersistenceService;
+        }
+        if (this.initInFlight) {
+            return this.initInFlight;
+        }
+
+        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
+        this.initInFlight = this.buildExtensionPassmanClientPersistenceService(resolvedPreferred);
+        try {
+            return await this.initInFlight;
+        } finally {
+            this.initInFlight = null;
+        }
+    }
+
+    /**
+     * Drop the current model store / persistence, invalidate PassmanClients, and rebuild for `preferred`.
+     */
+    public static async recreateExtensionPassmanClientPersistenceService(
+        preferred?: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        this.initInFlight = null;
+        this.extensionPersistenceService = undefined;
+        this.offlineModelStore = undefined;
+        inMemoryOnlyIndexedDBService.clear();
+
+        const { default: PassmanClientService } = await import("~/services/PassmanClientService");
+        PassmanClientService.invalidatePassmanClients();
+
+        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
+        return this.ensureExtensionPassmanClientPersistenceService(resolvedPreferred);
+    }
+
+    /**
+     * Persistence for PassmanClient: model store (+ optional decrypted-field cache).
+     * Call {@link ensureExtensionPassmanClientPersistenceService} first.
      */
     public static getExtensionPassmanClientPersistenceService() {
         if (!this.extensionPersistenceService) {
-            this.modelStore = new IndexedDbModelStore(
-                IndexedDbModelStore.DEFAULT_DB_NAME,
-                (reason) => {
-                    // Offline DTO cache was lost or the IDB connection died; drop decrypted-field cache too to prevent showing stale data.
-                    logger.warn(
-                        `[CustomStorageService] Model store IndexedDB "${IndexedDbModelStore.DEFAULT_DB_NAME}" reopened after unexpected loss (${reason}). Offline cache will refill on next network fetch.`
-                    );
-                    inMemoryOnlyIndexedDBService.clear();
-                }
-            );
-            this.extensionPersistenceService = new ExtensionPassmanClientPersistenceService(
-                true,
-                this.modelStore,
-                inMemoryOnlyIndexedDBService
+            throw new Error(
+                "CustomStorageService.ensureExtensionPassmanClientPersistenceService() must be awaited before getExtensionPassmanClientPersistenceService()"
             );
         }
         return this.extensionPersistenceService;
     }
 
-    private static getOfflineModelStore(): IndexedDbModelStore {
-        const persistence = this.getExtensionPassmanClientPersistenceService();
-        const store = (this.modelStore ?? persistence.getModelStore()) as IndexedDbModelStore;
-        this.modelStore = store;
-        return store;
+    private static async getOfflineModelStore(): Promise<OfflineModelStore> {
+        await this.ensureExtensionPassmanClientPersistenceService();
+        if (!this.offlineModelStore) {
+            throw new Error("Offline model store was not initialized");
+        }
+        return this.offlineModelStore;
     }
 
-    /**
-     * Approximate size of the passman-model-store IndexedDB offline cache.
-     */
     public static async estimateOfflineModelStoreSize(): Promise<IndexedDbModelStoreSizeEstimate> {
-        return this.getOfflineModelStore().estimateSize();
+        return (await this.getOfflineModelStore()).estimateSize();
     }
 
-    /**
-     * Deletes the offline model-store IndexedDB and clears the in-memory decrypted-field cache.
-     * Vault data is refilled from the server on the next fetch.
-     */
     public static async clearOfflineModelStore(): Promise<void> {
-        await this.getOfflineModelStore().clearDatabase();
+        await (await this.getOfflineModelStore()).clearDatabase();
         inMemoryOnlyIndexedDBService.clear();
     }
 }

--- a/src/services/ExtensionSettingsService.ts
+++ b/src/services/ExtensionSettingsService.ts
@@ -15,6 +15,7 @@ import {
     DEFAULT_EXTENSION_LOG_LEVEL,
     type ExtensionLogLevel,
 } from "~/lib/extensionLogLevel";
+import type { OfflineCacheStorageBackend } from "~/services/OfflineCacheStorageService";
 import { logger } from "~/services/ConsoleLoggingService";
 
 export type DefaultVaultInfo = {
@@ -65,6 +66,12 @@ export enum ExtensionSettingsOptions {
 
     /** Minimum console log level for {@link ConsoleLoggingService}. */
     logLevel,
+
+    /**
+     * Offline model-store backend: native IndexedDB (persistent) or in-memory fake-indexeddb
+     * (lost on service-worker restart; used when native IDB is blocked).
+     */
+    offlineCacheStorageBackend,
 }
 
 export interface ExtensionSettings {
@@ -89,6 +96,7 @@ export interface ExtensionSettings {
     [ExtensionSettingsOptions.doorhangerLayout]: DoorhangerLayout,
     [ExtensionSettingsOptions.doorhangerGravity]: DoorhangerGravity,
     [ExtensionSettingsOptions.logLevel]: ExtensionLogLevel,
+    [ExtensionSettingsOptions.offlineCacheStorageBackend]: OfflineCacheStorageBackend,
 }
 
 /**
@@ -187,6 +195,9 @@ export default class ExtensionSettingsService {
                 break;
             case ExtensionSettingsOptions.logLevel:
                 returnValue = DEFAULT_EXTENSION_LOG_LEVEL as ExtensionSettings[K];
+                break;
+            case ExtensionSettingsOptions.offlineCacheStorageBackend:
+                returnValue = "indexeddb" as ExtensionSettings[K];
                 break;
             default:
                 returnValue = null;

--- a/src/services/InMemoryModelStore.test.ts
+++ b/src/services/InMemoryModelStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import InMemoryModelStore from "./InMemoryModelStore";
+
+const fakeConnectionId = "https://example.com|alice|passman";
+
+describe("InMemoryModelStore", () => {
+    test("put/get vault list is namespaced by connectionId", async () => {
+        const store = new InMemoryModelStore();
+        const listing = [
+            {
+                vault_id: 1,
+                guid: "v1",
+                name: "Vault",
+                created: 1,
+                public_sharing_key: null,
+                last_access: 0,
+                challenge_password: "x",
+                delete_request_pending: false,
+            },
+        ];
+
+        await store.putVaultList(fakeConnectionId, listing);
+        expect(await store.getVaultList(fakeConnectionId)).toEqual(listing);
+        expect(await store.getVaultList("other")).toBeUndefined();
+
+        const size = await store.estimateSize();
+        expect(size.vaultListCount).toBe(1);
+    });
+
+    test("put/get/delete credential and clearDatabase", async () => {
+        const testCredentialGuid = "c1";
+        const testCredential2Guid = "c2";
+        const testVaultGuid = "v1";
+        const store = new InMemoryModelStore();
+        const credential = {
+            encryptedData: { guid: testCredentialGuid },
+        } as any;
+        const credential2 = {
+            encryptedData: { guid: testCredential2Guid },
+        } as any;
+
+        await store.putCredential(fakeConnectionId, testVaultGuid, credential);
+        expect(await store.getCredential(fakeConnectionId, testVaultGuid, testCredentialGuid)).toEqual(credential);
+        await store.putCredential(fakeConnectionId, testVaultGuid, credential2);
+        expect(await store.getCredential(fakeConnectionId, testVaultGuid, testCredential2Guid)).toEqual(credential2);
+
+        const size1 = await store.estimateSize();
+        expect(size1.vaultListCount).toBe(0);
+        expect(size1.credentialCount).toBe(2);
+        expect(size1.bytes).toBeGreaterThan(0);
+
+        await store.deleteCredential(fakeConnectionId, testVaultGuid, testCredentialGuid);
+        expect(await store.getCredential(fakeConnectionId, testVaultGuid, testCredentialGuid)).toBeUndefined();
+
+        await store.putVaultList(fakeConnectionId, []);
+        await store.clearDatabase();
+
+        const size2 = await store.estimateSize();
+        expect(size2.vaultListCount).toBe(0);
+        expect(size2.credentialCount).toBe(0);
+        expect(size2.bytes).toBe(0);
+    });
+});

--- a/src/services/InMemoryModelStore.ts
+++ b/src/services/InMemoryModelStore.ts
@@ -1,0 +1,141 @@
+import type { ModelStoreInterface } from "@binsky/passman-client-ts/lib/Interfaces/ModelStoreInterface";
+import type { GenericVaultInformationFromServerInterface } from "@binsky/passman-client-ts/lib/Interfaces/Vault/GenericVaultInformationFromServerInterface";
+import type { SerializableTransferFullVaultInterface } from "@binsky/passman-client-ts/lib/Interfaces/Vault/SerializableTransferFullVaultInterface";
+import type { SerializableTransferCredentialInterface } from "@binsky/passman-client-ts/lib/Interfaces/Credential/SerializableTransferCredentialInterface";
+import type { IndexedDbModelStoreSizeEstimate } from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
+
+/**
+ * Volatile {@link ModelStoreInterface} for when native IndexedDB is unavailable or the user chooses in-memory cache.
+ * Using fake-indexeddb as polyfill was not successful, so unfortunately we have to use this dedicated model store. (hopefully without unexpected side effects)
+ */
+export default class InMemoryModelStore implements ModelStoreInterface {
+    private readonly vaultLists = new Map<string, GenericVaultInformationFromServerInterface[]>();
+    private readonly vaults = new Map<string, SerializableTransferFullVaultInterface["serializableSpecificVaultInformation"]>();
+    private readonly credentials = new Map<string, SerializableTransferCredentialInterface>();
+
+    private static vaultKey(connectionId: string, guid: string): string {
+        return `${connectionId}::${guid}`;
+    }
+
+    private static credentialKey(connectionId: string, vaultGuid: string, credentialGuid: string): string {
+        return `${connectionId}::${vaultGuid}::${credentialGuid}`;
+    }
+
+    async getVaultList(connectionId: string) {
+        return this.vaultLists.get(connectionId);
+    }
+
+    async putVaultList(connectionId: string, vaultList: GenericVaultInformationFromServerInterface[]) {
+        this.vaultLists.set(connectionId, vaultList);
+    }
+
+    async getVault(connectionId: string, guid: string) {
+        const vaultInfo = this.vaults.get(InMemoryModelStore.vaultKey(connectionId, guid));
+        if (!vaultInfo) {
+            return undefined;
+        }
+        const prefix = `${connectionId}::${guid}::`;
+        const encryptedSerializableCredentials: SerializableTransferCredentialInterface[] = [];
+        for (const [key, credential] of this.credentials) {
+            if (key.startsWith(prefix)) {
+                encryptedSerializableCredentials.push(credential);
+            }
+        }
+        return {
+            serializableSpecificVaultInformation: vaultInfo,
+            encryptedSerializableCredentials,
+        };
+    }
+
+    /**
+     * Put a new vault into the model store.
+     * Not that computationally efficient since all credentials are re-added to the model store.
+     * @param connectionId 
+     * @param vault 
+     */
+    async putVault(connectionId: string, vault: SerializableTransferFullVaultInterface) {
+        const guid = vault.serializableSpecificVaultInformation.guid;
+        this.vaults.set(
+            InMemoryModelStore.vaultKey(connectionId, guid),
+            vault.serializableSpecificVaultInformation
+        );
+
+        // remove all known old vault associated credentials, before filling in the new/current ones;
+        // may looks strange, but it's more effective than checking for new and comparing existing credentials in a loop
+        const vaultPrefix = `${connectionId}::${guid}::`;
+        for (const key of [...this.credentials.keys()]) {
+            if (key.startsWith(vaultPrefix)) {
+                this.credentials.delete(key);
+            }
+        }
+        for (const credential of vault.encryptedSerializableCredentials) {
+            const credentialGuid = credential.encryptedData.guid;
+            this.credentials.set(
+                InMemoryModelStore.credentialKey(connectionId, guid, credentialGuid),
+                credential
+            );
+        }
+    }
+
+    async deleteVault(connectionId: string, guid: string) {
+        this.vaults.delete(InMemoryModelStore.vaultKey(connectionId, guid));
+        const prefix = `${connectionId}::${guid}::`;
+        for (const key of [...this.credentials.keys()]) {
+            if (key.startsWith(prefix)) {
+                this.credentials.delete(key);
+            }
+        }
+    }
+
+    async getCredential(connectionId: string, vaultGuid: string, credentialGuid: string) {
+        return this.credentials.get(
+            InMemoryModelStore.credentialKey(connectionId, vaultGuid, credentialGuid)
+        );
+    }
+
+    async putCredential(
+        connectionId: string,
+        vaultGuid: string,
+        credential: SerializableTransferCredentialInterface
+    ) {
+        const credentialGuid = credential.encryptedData.guid;
+        this.credentials.set(
+            InMemoryModelStore.credentialKey(connectionId, vaultGuid, credentialGuid),
+            credential
+        );
+    }
+
+    async deleteCredential(connectionId: string, vaultGuid: string, credentialGuid: string) {
+        this.credentials.delete(
+            InMemoryModelStore.credentialKey(connectionId, vaultGuid, credentialGuid)
+        );
+    }
+
+    async estimateSize(): Promise<IndexedDbModelStoreSizeEstimate> {
+        let bytes = 0;
+        const measure = (value: unknown) => {
+            bytes += new Blob([JSON.stringify(value)]).size;
+        };
+        for (const value of this.vaultLists.values()) {
+            measure(value);
+        }
+        for (const value of this.vaults.values()) {
+            measure(value);
+        }
+        for (const value of this.credentials.values()) {
+            measure(value);
+        }
+        return {
+            bytes,
+            vaultListCount: this.vaultLists.size,
+            vaultCount: this.vaults.size,
+            credentialCount: this.credentials.size,
+        };
+    }
+
+    async clearDatabase(): Promise<void> {
+        this.vaultLists.clear();
+        this.vaults.clear();
+        this.credentials.clear();
+    }
+}

--- a/src/services/NotifyingModelStore.ts
+++ b/src/services/NotifyingModelStore.ts
@@ -1,0 +1,100 @@
+import type { ModelStoreInterface } from "@binsky/passman-client-ts/lib/Interfaces/ModelStoreInterface";
+import type { GenericVaultInformationFromServerInterface } from "@binsky/passman-client-ts/lib/Interfaces/Vault/GenericVaultInformationFromServerInterface";
+import type { SerializableTransferFullVaultInterface } from "@binsky/passman-client-ts/lib/Interfaces/Vault/SerializableTransferFullVaultInterface";
+import type { SerializableTransferCredentialInterface } from "@binsky/passman-client-ts/lib/Interfaces/Credential/SerializableTransferCredentialInterface";
+import {
+    isIndexedDbMutationDenied,
+    isIndexedDbQuotaExceeded,
+} from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
+import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
+import { logger } from "~/services/ConsoleLoggingService";
+import ExtensionUnlockService from "./ExtensionUnlockService";
+
+/**
+ * Wraps a model store and turns IndexedDB policy/quota failures into session notices + soft-failed writes
+ * so setup/login is not killed by a raw DOMException.
+ */
+export default class NotifyingModelStore implements ModelStoreInterface {
+    constructor(private readonly inner: ModelStoreInterface) {}
+
+    private async handleError(error: unknown, softFail: boolean): Promise<boolean> {
+        if (isIndexedDbMutationDenied(error)) {
+            // Enqueue only when the extension is finally set up and ready to use, otherwise it would feel inconsistent and noisy.
+            // This way it should only "sticky" notify on unexpected state changes.
+            // Since setup and settings UI should gatekeep / early detect potential IDB access problems, we should not need that hardfail fallback for now.
+            if (await ExtensionUnlockService.isSetupDone()) {
+                await OfflineCacheStorageService.enqueueNotice(
+                    "unavailable",
+                    error instanceof Error ? error.message : undefined
+                );
+            }
+            logger.warn("[NotifyingModelStore] IndexedDB mutations denied", error);
+            return softFail;
+        }
+        if (isIndexedDbQuotaExceeded(error)) {
+            if (await ExtensionUnlockService.isSetupDone()) {
+                await OfflineCacheStorageService.enqueueNotice(
+                    "quota",
+                    error instanceof Error ? error.message : undefined
+                );
+            }
+            logger.warn("[NotifyingModelStore] IndexedDB quota exceeded", error);
+            return softFail;
+        }
+        return false;
+    }
+
+    private async write(op: () => Promise<void>): Promise<void> {
+        try {
+            await op();
+        } catch (error) {
+            if (await this.handleError(error, true)) {
+                return;
+            }
+            throw error;
+        }
+    }
+
+    private async read<T>(op: () => Promise<T>): Promise<T | undefined> {
+        try {
+            return await op();
+        } catch (error) {
+            if (await this.handleError(error, true)) {
+                return undefined;
+            }
+            throw error;
+        }
+    }
+
+    getVaultList(connectionId: string) {
+        return this.read(() => this.inner.getVaultList(connectionId));
+    }
+
+    putVaultList(connectionId: string, vaultList: GenericVaultInformationFromServerInterface[]) {
+        return this.write(() => this.inner.putVaultList(connectionId, vaultList));
+    }
+
+    getVault(connectionId: string, guid: string) {
+        return this.read(() => this.inner.getVault(connectionId, guid));
+    }
+
+    putVault(connectionId: string, vault: SerializableTransferFullVaultInterface) {
+        return this.write(() => this.inner.putVault(connectionId, vault));
+    }
+
+    deleteVault(connectionId: string, guid: string) {
+        return this.write(() => this.inner.deleteVault(connectionId, guid));
+    }
+
+    getCredential(connectionId: string, vaultGuid: string, credentialGuid: string) {
+        return this.read(() => this.inner.getCredential(connectionId, vaultGuid, credentialGuid));
+    }
+
+    putCredential(connectionId: string, vaultGuid: string, credential: SerializableTransferCredentialInterface) {
+        return this.write(() => this.inner.putCredential(connectionId, vaultGuid, credential));
+    }
+
+    deleteCredential(connectionId: string, vaultGuid: string, credentialGuid: string) {
+        return this.write(() => this.inner.deleteCredential(connectionId, vaultGuid, credentialGuid));
+    }
+}

--- a/src/services/OfflineCachePersistenceService.ts
+++ b/src/services/OfflineCachePersistenceService.ts
@@ -1,0 +1,150 @@
+import ExtensionPassmanClientPersistenceService from "./ExtensionPassmanClientPersistenceService";
+import { customIndexedDBService as inMemoryOnlyIndexedDBService } from "./CustomIndexedDBService";
+import {
+    IndexedDbModelStore,
+    type IndexedDbModelStoreSizeEstimate,
+} from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
+import type { ModelStoreInterface } from "@binsky/passman-client-ts/lib/Interfaces/ModelStoreInterface";
+import OfflineCacheStorageService, {
+    type OfflineCacheStorageBackend,
+} from "~/services/OfflineCacheStorageService";
+import InMemoryModelStore from "~/services/InMemoryModelStore";
+import NotifyingModelStore from "~/services/NotifyingModelStore";
+import ExtensionSettingsService, { ExtensionSettingsOptions } from "~/services/ExtensionSettingsService";
+import { logger } from "@/services/ConsoleLoggingService";
+
+type OfflineModelStore = (IndexedDbModelStore | InMemoryModelStore) & ModelStoreInterface & {
+    estimateSize(): Promise<IndexedDbModelStoreSizeEstimate>;
+    clearDatabase(): Promise<void>;
+};
+
+/**
+ * Lifecycle for the offline-cache PassmanClient persistence singleton (model store + optional decrypted-field cache),
+ * including the IndexedDB/in-memory backend probe/resolution and the user's persisted backend preference.
+ */
+export default class OfflineCachePersistenceService {
+    private static extensionPersistenceService?: ExtensionPassmanClientPersistenceService;
+    private static offlineModelStore?: OfflineModelStore;
+    private static initInFlight: Promise<ExtensionPassmanClientPersistenceService> | null = null;
+
+    private static async readPreferredOfflineCacheBackend(): Promise<OfflineCacheStorageBackend> {
+        try {
+            const value = await ExtensionSettingsService.getPartialExtensionSettings(
+                ExtensionSettingsOptions.offlineCacheStorageBackend,
+                true
+            );
+            if (value === "indexeddb" || value === "memory") {
+                return value;
+            }
+        } catch {
+            // SecureStorage may be locked; fall through to default
+        }
+        return OfflineCacheStorageService.DEFAULT_BACKEND;
+    }
+
+    private static async persistPreferredOfflineCacheBackend(
+        backend: OfflineCacheStorageBackend
+    ): Promise<void> {
+        try {
+            await ExtensionSettingsService.updatePartialExtensionSettings(
+                ExtensionSettingsOptions.offlineCacheStorageBackend,
+                backend
+            );
+        } catch (error) {
+            logger.warn(
+                "[OfflineCachePersistenceService] Could not persist offlineCacheStorageBackend (SecureStorage locked?)",
+                error
+            );
+        }
+    }
+
+    private static createOfflineModelStore(effective: OfflineCacheStorageBackend): OfflineModelStore {
+        if (effective === "memory") {
+            return new InMemoryModelStore();
+        }
+        return new IndexedDbModelStore(
+            IndexedDbModelStore.DEFAULT_DB_NAME,
+            (reason) => {
+                logger.warn(
+                    `[OfflineCachePersistenceService] Model store IndexedDB "${IndexedDbModelStore.DEFAULT_DB_NAME}" reopened after unexpected loss (${reason}). Offline cache will refill on next network fetch.`
+                );
+                inMemoryOnlyIndexedDBService.clear();
+            }
+        );
+    }
+
+    private static async buildExtensionPassmanClientPersistenceService(
+        preferred: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        const effective = await OfflineCacheStorageService.resolveEffectiveBackend(preferred);
+
+        if (OfflineCacheStorageService.isForcedFallback()) {
+            await this.persistPreferredOfflineCacheBackend("memory");
+        }
+
+        this.offlineModelStore = this.createOfflineModelStore(effective);
+        this.extensionPersistenceService = new ExtensionPassmanClientPersistenceService(
+            true,
+            new NotifyingModelStore(this.offlineModelStore),
+            inMemoryOnlyIndexedDBService
+        );
+        return this.extensionPersistenceService;
+    }
+
+    /**
+     * Probe/resolve offline-cache backend and return the PassmanClient persistence singleton,
+     * creating it on first call. Never throws for being called too early.
+     */
+    public static async get(
+        preferred?: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        if (this.extensionPersistenceService) {
+            return this.extensionPersistenceService;
+        }
+        if (this.initInFlight) {
+            return this.initInFlight;
+        }
+
+        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
+        this.initInFlight = this.buildExtensionPassmanClientPersistenceService(resolvedPreferred);
+        try {
+            return await this.initInFlight;
+        } finally {
+            this.initInFlight = null;
+        }
+    }
+
+    /**
+     * Drop the current model store / persistence and rebuild for "preferred".
+     * Does not invalidate PassmanClients; callers that swap the backend under a live client
+     * must call {@link PassmanClientService.invalidatePassmanClients} themselves.
+     */
+    public static async recreate(
+        preferred?: OfflineCacheStorageBackend
+    ): Promise<ExtensionPassmanClientPersistenceService> {
+        this.initInFlight = null;
+        this.extensionPersistenceService = undefined;
+        this.offlineModelStore = undefined;
+        inMemoryOnlyIndexedDBService.clear();
+
+        const resolvedPreferred = preferred ?? await this.readPreferredOfflineCacheBackend();
+        return this.get(resolvedPreferred);
+    }
+
+    private static async getOfflineModelStore(): Promise<OfflineModelStore> {
+        await this.get();
+        if (!this.offlineModelStore) {
+            throw new Error("Offline model store was not initialized");
+        }
+        return this.offlineModelStore;
+    }
+
+    public static async estimateSize(): Promise<IndexedDbModelStoreSizeEstimate> {
+        return (await this.getOfflineModelStore()).estimateSize();
+    }
+
+    public static async clear(): Promise<void> {
+        await (await this.getOfflineModelStore()).clearDatabase();
+        inMemoryOnlyIndexedDBService.clear();
+    }
+}

--- a/src/services/OfflineCacheStorageService.test.ts
+++ b/src/services/OfflineCacheStorageService.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * OfflineCacheStorageService pulls in webextension Storage; stub the session area and ExtensionUnlockService before importing the module under test
+ */
+const sessionData = new Map<string, unknown>();
+
+mock.module("@/lib/storage", () => ({
+    Storage: class {
+        async get<T>(key: string): Promise<T | undefined> {
+            return sessionData.get(key) as T | undefined;
+        }
+        async set(key: string, value: unknown): Promise<void> {
+            sessionData.set(key, value);
+        }
+        async remove(key: string): Promise<void> {
+            sessionData.delete(key);
+        }
+        async clear(): Promise<void> {
+            sessionData.clear();
+        }
+        async getAll() {
+            return Object.fromEntries(sessionData);
+        }
+        setNamespace() {}
+    },
+}));
+
+mock.module("~/services/ExtensionUnlockService", () => ({
+    default: {
+        isSetupDone: async () => true,
+    },
+}));
+
+mock.module("~/services/ConsoleLoggingService", () => ({
+    logger: {
+        warn: () => {},
+        info: () => {},
+        error: () => {},
+        debug: () => {},
+        log: () => {},
+    },
+}));
+
+const { default: OfflineCacheStorageService } = await import("./OfflineCacheStorageService");
+
+describe("OfflineCacheStorageService.resolveEffectiveBackend", () => {
+    const originalIndexedDB = globalThis.indexedDB;
+
+    beforeEach(() => {
+        sessionData.clear();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(globalThis, "indexedDB", {
+            value: originalIndexedDB,
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    test("preferred memory uses memory without forced fallback", async () => {
+        const effective = await OfflineCacheStorageService.resolveEffectiveBackend("memory");
+        expect(effective).toBe("memory");
+        expect(OfflineCacheStorageService.isForcedFallback()).toBe(false);
+        expect(OfflineCacheStorageService.getEffective()).toBe("memory");
+        expect(await OfflineCacheStorageService.consumeNotice()).toBeUndefined();
+    });
+
+    test("indexeddb preferred with missing factory forces memory and enqueues notice", async () => {
+        Object.defineProperty(globalThis, "indexedDB", {
+            value: undefined,
+            configurable: true,
+            writable: true,
+        });
+
+        const effective = await OfflineCacheStorageService.resolveEffectiveBackend("indexeddb");
+        expect(effective).toBe("memory");
+        expect(OfflineCacheStorageService.isForcedFallback()).toBe(true);
+        expect(OfflineCacheStorageService.getPreferred()).toBe("memory");
+        expect(OfflineCacheStorageService.getLastErrorCode()).toBe("unavailable");
+
+        const notice = await OfflineCacheStorageService.consumeNotice();
+        expect(notice?.code).toBe("unavailable");
+        expect(await OfflineCacheStorageService.consumeNotice()).toBeUndefined();
+    });
+
+    test("indexeddb preferred when probe write fails forces memory", async () => {
+        const fakeFactory = {
+            open: () => {
+                const request: any = {};
+                queueMicrotask(() => {
+                    request.onerror?.();
+                });
+                return request;
+            },
+            deleteDatabase: () => {
+                const request: any = {};
+                queueMicrotask(() => request.onsuccess?.());
+                return request;
+            },
+        };
+        Object.defineProperty(globalThis, "indexedDB", {
+            value: fakeFactory,
+            configurable: true,
+            writable: true,
+        });
+
+        const effective = await OfflineCacheStorageService.resolveEffectiveBackend("indexeddb");
+        expect(effective).toBe("memory");
+        expect(OfflineCacheStorageService.isForcedFallback()).toBe(true);
+    });
+});

--- a/src/services/OfflineCacheStorageService.ts
+++ b/src/services/OfflineCacheStorageService.ts
@@ -1,0 +1,137 @@
+import { Storage } from "@/lib/storage";
+import { logger } from "~/services/ConsoleLoggingService";
+import ExtensionUnlockService from "./ExtensionUnlockService";
+
+export type OfflineCacheStorageBackend = "indexeddb" | "memory";
+export type OfflineCacheNoticeCode = "unavailable" | "quota";
+
+export interface OfflineCacheNotice {
+    code: OfflineCacheNoticeCode;
+    at: number;
+    detail?: string;
+}
+
+const PROBE_DB = "passman-idb-probe";
+const NOTICE_KEY = "offlineCacheStorageNotice";
+
+/**
+ * Probes native IndexedDB and tracks whether the offline model store should use persistent
+ * IndexedDB or a volatile in-memory {@link InMemoryModelStore}, since Firefox "Never remember history"
+ * blocks native IndexedDB writes.
+ */
+export default class OfflineCacheStorageService {
+    public static readonly DEFAULT_BACKEND: OfflineCacheStorageBackend = "indexeddb";
+
+    private static session = new Storage("session");
+    private static preferred: OfflineCacheStorageBackend = this.DEFAULT_BACKEND;
+    private static effective: OfflineCacheStorageBackend = this.DEFAULT_BACKEND;
+    private static nativeAvailable: boolean | undefined;
+    private static forcedFallback = false;
+    private static lastErrorCode: OfflineCacheNoticeCode | undefined;
+
+    public static getPreferred = (): OfflineCacheStorageBackend => this.preferred;
+    public static getEffective = (): OfflineCacheStorageBackend => this.effective;
+    public static isNativeAvailable = (): boolean | undefined => this.nativeAvailable;
+    public static isForcedFallback = (): boolean => this.forcedFallback;
+    public static getLastErrorCode = (): OfflineCacheNoticeCode | undefined => this.lastErrorCode;
+
+    /** Throwaway write against native IndexedDB. */
+    public static async probeNativeIndexedDb(): Promise<boolean> {
+        const factory = globalThis.indexedDB;
+        if (!factory) {
+            this.nativeAvailable = false;
+            return false;
+        }
+
+        const available = await new Promise<boolean>((resolve) => {
+            const done = (ok: boolean) => {
+                try {
+                    factory.deleteDatabase(PROBE_DB);
+                } catch {
+                    // ignore
+                }
+                resolve(ok);
+            };
+
+            try {
+                const req = factory.open(PROBE_DB, 1);
+                req.onerror = () => done(false);
+                req.onupgradeneeded = () => {
+                    try {
+                        req.result.createObjectStore("p");
+                    } catch {
+                        done(false);
+                    }
+                };
+                req.onsuccess = () => {
+                    const db = req.result;
+                    try {
+                        const tx = db.transaction("p", "readwrite");
+                        tx.objectStore("p").put(1, "k");
+                        tx.oncomplete = () => {
+                            db.close();
+                            done(true);
+                        };
+                        tx.onerror = () => {
+                            db.close();
+                            done(false);
+                        };
+                    } catch {
+                        db.close();
+                        done(false);
+                    }
+                };
+            } catch {
+                done(false);
+            }
+        });
+
+        this.nativeAvailable = available;
+        return available;
+    }
+
+    /**
+     * Resolve the backend for the model store. If IndexedDB is preferred but unusable, force memory
+     * and enqueue an `unavailable` notice.
+     */
+    public static async resolveEffectiveBackend(
+        preferred: OfflineCacheStorageBackend = OfflineCacheStorageService.DEFAULT_BACKEND
+    ): Promise<OfflineCacheStorageBackend> {
+        this.preferred = preferred;
+
+        if (preferred === "memory" || !(await this.probeNativeIndexedDb())) {
+            this.forcedFallback = preferred === "indexeddb";
+            this.lastErrorCode = this.forcedFallback ? "unavailable" : undefined;
+            this.effective = "memory";
+            if (this.forcedFallback) {
+                this.preferred = "memory";
+                logger.warn(
+                    "[OfflineCacheStorageService] Native IndexedDB unavailable; using in-memory cache (lost on SW restart)"
+                );
+                if (await ExtensionUnlockService.isSetupDone()) {
+                    await this.enqueueNotice("unavailable");
+                }
+            }
+            return "memory";
+        }
+
+        this.forcedFallback = false;
+        this.lastErrorCode = undefined;
+        this.effective = "indexeddb";
+        return "indexeddb";
+    }
+
+    public static async enqueueNotice(code: OfflineCacheNoticeCode, detail?: string): Promise<void> {
+        this.lastErrorCode = code;
+        await this.session.set(NOTICE_KEY, { code, detail, at: Date.now() } satisfies OfflineCacheNotice);
+    }
+
+    /** Read and clear the session notice (popup/options mount). */
+    public static async consumeNotice(): Promise<OfflineCacheNotice | undefined> {
+        const notice = await this.session.get<OfflineCacheNotice>(NOTICE_KEY);
+        if (notice) {
+            await this.session.remove(NOTICE_KEY);
+        }
+        return notice;
+    }
+}

--- a/src/services/PassmanClientService.ts
+++ b/src/services/PassmanClientService.ts
@@ -58,7 +58,7 @@ export default class PassmanClientService {
         // Shared IndexedDB model store with the background client; restore fills preloaded/full vaults offline
         const client = await PassmanClient.createInstance(
             first,
-            new NextcloudServerMessagingConnector(first, logger),
+            new NextcloudServerMessagingConnector(first, logger, persistence),
             logger,
             persistence
         );
@@ -66,7 +66,7 @@ export default class PassmanClientService {
         for (const serverData of rest) {
             await client.addConnection(
                 serverData,
-                new NextcloudServerMessagingConnector(serverData, logger),
+                new NextcloudServerMessagingConnector(serverData, logger, persistence),
                 logger,
                 persistence
             );
@@ -109,7 +109,7 @@ export default class PassmanClientService {
                 const logger = new CustomPopupPassmanClientLoggingService();
                 await client.addConnection(
                     serverData,
-                    new NextcloudServerMessagingConnector(serverData, logger),
+                    new NextcloudServerMessagingConnector(serverData, logger, persistence),
                     logger,
                     persistence
                 );
@@ -167,7 +167,7 @@ export default class PassmanClientService {
             const popupServerData: NextcloudServerInfoInterface = { ...serverData };
             const connection = await PassmanClientService.popupPassmanClient.addConnection(
                 popupServerData,
-                new NextcloudServerMessagingConnector(popupServerData, logger),
+                new NextcloudServerMessagingConnector(popupServerData, logger, persistence),
                 logger,
                 persistence
             );

--- a/src/services/PassmanClientService.ts
+++ b/src/services/PassmanClientService.ts
@@ -5,7 +5,7 @@ import type {
 import { PassmanServerConnection } from "@binsky/passman-client-ts/lib/Model/PassmanServerConnection";
 import { NextcloudServerMessagingConnector } from "@/lib/NextcloudServerMessagingConnector";
 import { BackendPassmanClient } from "@/lib/BackendPassmanClient";
-import CustomStorageService from "./CustomStorageService";
+import OfflineCachePersistenceService from "./OfflineCachePersistenceService";
 import { CustomPopupPassmanClientLoggingService } from "./frontend/CustomPassmanClientLoggingService";
 import ServerConnectionDirectoryService from "./ServerConnectionDirectoryService";
 import { logger } from "@/services/ConsoleLoggingService";
@@ -28,7 +28,7 @@ export default class PassmanClientService {
             return null;
         }
 
-        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+        const persistence = await OfflineCachePersistenceService.get();
         const [first, ...rest] = connections;
         const client = await BackendPassmanClient.createInstance(first, undefined, undefined, persistence);
 
@@ -53,7 +53,7 @@ export default class PassmanClientService {
         }
 
         const logger = new CustomPopupPassmanClientLoggingService();
-        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+        const persistence = await OfflineCachePersistenceService.get();
         const [first, ...rest] = connections;
         // Shared IndexedDB model store with the background client; restore fills preloaded/full vaults offline
         const client = await PassmanClient.createInstance(
@@ -100,7 +100,7 @@ export default class PassmanClientService {
             }
         }
 
-        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+        const persistence = await OfflineCachePersistenceService.get();
         for (const [connectionId, serverData] of directoryById) {
             if (client.getConnection(connectionId)) {
                 continue;
@@ -148,7 +148,7 @@ export default class PassmanClientService {
         serverData: NextcloudServerInfoInterface,
         makeActive: boolean
     ): Promise<void> => {
-        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+        const persistence = await OfflineCachePersistenceService.get();
 
         if (PassmanClientService.backendPassmanClient) {
             const connection = await PassmanClientService.backendPassmanClient.addConnection(
@@ -196,7 +196,6 @@ export default class PassmanClientService {
     };
 
     public static getBackendPassmanClient = async () => {
-        await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const { connections, activeConnectionId } = await ServerConnectionDirectoryService.getDirectory();
 
         if (PassmanClientService.backendPassmanClient) {
@@ -223,7 +222,6 @@ export default class PassmanClientService {
     };
 
     public static getPopupPassmanClient = async () => {
-        await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const { connections, activeConnectionId } = await ServerConnectionDirectoryService.getDirectory();
 
         if (PassmanClientService.popupPassmanClient) {

--- a/src/services/PassmanClientService.ts
+++ b/src/services/PassmanClientService.ts
@@ -28,7 +28,7 @@ export default class PassmanClientService {
             return null;
         }
 
-        const persistence = CustomStorageService.getExtensionPassmanClientPersistenceService();
+        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const [first, ...rest] = connections;
         const client = await BackendPassmanClient.createInstance(first, undefined, undefined, persistence);
 
@@ -53,7 +53,7 @@ export default class PassmanClientService {
         }
 
         const logger = new CustomPopupPassmanClientLoggingService();
-        const persistence = CustomStorageService.getExtensionPassmanClientPersistenceService();
+        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const [first, ...rest] = connections;
         // Shared IndexedDB model store with the background client; restore fills preloaded/full vaults offline
         const client = await PassmanClient.createInstance(
@@ -100,7 +100,7 @@ export default class PassmanClientService {
             }
         }
 
-        const persistence = CustomStorageService.getExtensionPassmanClientPersistenceService();
+        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         for (const [connectionId, serverData] of directoryById) {
             if (client.getConnection(connectionId)) {
                 continue;
@@ -148,7 +148,7 @@ export default class PassmanClientService {
         serverData: NextcloudServerInfoInterface,
         makeActive: boolean
     ): Promise<void> => {
-        const persistence = CustomStorageService.getExtensionPassmanClientPersistenceService();
+        const persistence = await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
 
         if (PassmanClientService.backendPassmanClient) {
             const connection = await PassmanClientService.backendPassmanClient.addConnection(
@@ -196,6 +196,7 @@ export default class PassmanClientService {
     };
 
     public static getBackendPassmanClient = async () => {
+        await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const { connections, activeConnectionId } = await ServerConnectionDirectoryService.getDirectory();
 
         if (PassmanClientService.backendPassmanClient) {
@@ -222,6 +223,7 @@ export default class PassmanClientService {
     };
 
     public static getPopupPassmanClient = async () => {
+        await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
         const { connections, activeConnectionId } = await ServerConnectionDirectoryService.getDirectory();
 
         if (PassmanClientService.popupPassmanClient) {

--- a/src/services/frontend/NotyService.ts
+++ b/src/services/frontend/NotyService.ts
@@ -23,6 +23,22 @@ export default class NotyService {
         type: "error"
     });
 
+    /** Sticky warning until the user dismisses it */
+    public static readonly notyPinnedWarning = (message: string, title?: string) => addToast({
+        message,
+        title,
+        type: "warning",
+        duration: 0,
+    });
+
+    /** Sticky error until the user dismisses it */
+    public static readonly notyPinnedError = (message: string, title?: string) => addToast({
+        message,
+        title,
+        type: "error",
+        duration: 0,
+    });
+
     public static readonly notyFormFieldErrors = (errors: IFormFieldError[]) => {
         errors.forEach((error: IFormFieldError) => NotyService.notyError(error.error));
     };

--- a/src/services/frontend/flushOfflineCacheNotices.ts
+++ b/src/services/frontend/flushOfflineCacheNotices.ts
@@ -1,0 +1,18 @@
+import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
+import NotyService from "~/services/frontend/NotyService";
+import { i18n } from "~/lib/i18n";
+
+/**
+ * Consume a session offline-cache notice and show a pinned toast (popup/options).
+ */
+export async function flushOfflineCacheNotices(): Promise<void> {
+    const notice = await OfflineCacheStorageService.consumeNotice();
+    if (!notice) {
+        return;
+    }
+    if (notice.code === "quota") {
+        NotyService.notyPinnedError(i18n.getMessage("offline_cache_quota_notice"));
+        return;
+    }
+    NotyService.notyPinnedWarning(i18n.getMessage("offline_cache_forced_fallback_notice"));
+}

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -19,6 +19,10 @@
     import packageJson from "../../../package.json";
     import { i18n } from "~/lib/i18n";
     import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCacheStorageService, {
+        type OfflineCacheStorageBackend,
+    } from "~/services/OfflineCacheStorageService";
+    import { sendMessage } from "@/entrypoints/background/messaging";
     import type { IndexedDbModelStoreSizeEstimate } from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
     import {
         DEFAULT_DOORHANGER_GRAVITY,
@@ -44,6 +48,7 @@
         | ExtensionSettingsOptions.doorhangerLayout
         | ExtensionSettingsOptions.doorhangerGravity
         | ExtensionSettingsOptions.logLevel
+        | ExtensionSettingsOptions.offlineCacheStorageBackend
     >;
 
     const extensionVersion = packageJson.version;
@@ -61,6 +66,7 @@
         [ExtensionSettingsOptions.doorhangerLayout]: DEFAULT_DOORHANGER_LAYOUT,
         [ExtensionSettingsOptions.doorhangerGravity]: DEFAULT_DOORHANGER_GRAVITY,
         [ExtensionSettingsOptions.logLevel]: DEFAULT_EXTENSION_LOG_LEVEL,
+        [ExtensionSettingsOptions.offlineCacheStorageBackend]: OfflineCacheStorageService.DEFAULT_BACKEND,
     });
 
     const doorhangerLayoutOptions: { [key: string]: string } = {
@@ -92,6 +98,14 @@
         label: logLevelOptions[level],
         value: level,
     }));
+    const offlineCacheBackendOptions: Record<OfflineCacheStorageBackend, string> = {
+        indexeddb: i18n.getMessage('offline_cache_storage_backend_indexeddb'),
+        memory: i18n.getMessage('offline_cache_storage_backend_memory'),
+    };
+    const offlineCacheBackendItems = (Object.keys(offlineCacheBackendOptions) as OfflineCacheStorageBackend[]).map((key) => ({
+        label: offlineCacheBackendOptions[key],
+        value: key,
+    }));
     let doorhangerLayoutSelectValue = $state({
         label: doorhangerLayoutOptions[DEFAULT_DOORHANGER_LAYOUT],
         value: DEFAULT_DOORHANGER_LAYOUT,
@@ -104,11 +118,16 @@
         label: logLevelOptions[DEFAULT_EXTENSION_LOG_LEVEL],
         value: DEFAULT_EXTENSION_LOG_LEVEL,
     });
+    let offlineCacheBackendSelectValue = $state({
+        label: offlineCacheBackendOptions[OfflineCacheStorageService.DEFAULT_BACKEND],
+        value: OfflineCacheStorageService.DEFAULT_BACKEND as OfflineCacheStorageBackend,
+    });
 
     $effect(() => {
         extendedSettings[ExtensionSettingsOptions.doorhangerLayout] = doorhangerLayoutSelectValue.value;
         extendedSettings[ExtensionSettingsOptions.doorhangerGravity] = doorhangerGravitySelectValue.value;
         extendedSettings[ExtensionSettingsOptions.logLevel] = logLevelSelectValue.value;
+        extendedSettings[ExtensionSettingsOptions.offlineCacheStorageBackend] = offlineCacheBackendSelectValue.value;
     });
 
     let lockSaveButton = $state(false);
@@ -117,6 +136,21 @@
     let offlineCacheSizeError = $state(false);
     let offlineCacheSizeLoading = $state(false);
     let clearingOfflineCache = $state(false);
+    let offlineCacheEffective = $state<OfflineCacheStorageBackend>(OfflineCacheStorageService.DEFAULT_BACKEND);
+    let offlineCacheForcedFallback = $state(false);
+
+    const syncOfflineCacheStatus = () => {
+        offlineCacheEffective = OfflineCacheStorageService.getEffective();
+        offlineCacheForcedFallback = OfflineCacheStorageService.isForcedFallback();
+    };
+
+    const setOfflineCacheBackendSelect = (backend: OfflineCacheStorageBackend) => {
+        offlineCacheBackendSelectValue = {
+            value: backend,
+            label: offlineCacheBackendOptions[backend],
+        };
+        extendedSettings[ExtensionSettingsOptions.offlineCacheStorageBackend] = backend;
+    };
 
     const formatBytes = (bytes: number): string => {
         if (bytes < 1024) {
@@ -159,18 +193,55 @@
         }
     };
 
+    /**
+     * Recreate offline model-store backends (frontend + background) and refresh size/status UI.
+     * @returns false when IndexedDB was requested but unavailable (forced memory); true otherwise
+     */
+    const applyOfflineCacheStorageBackend = async (
+        selectedBackend: OfflineCacheStorageBackend
+    ): Promise<boolean> => {
+        await CustomStorageService.recreateExtensionPassmanClientPersistenceService(selectedBackend);
+        const bg = await sendMessage("recreateOfflineCachePersistence", { preferred: selectedBackend });
+        syncOfflineCacheStatus();
+
+        const effectiveMemory =
+            OfflineCacheStorageService.getEffective() === "memory" || bg.effective === "memory";
+        offlineCacheEffective = effectiveMemory ? "memory" : "indexeddb";
+        offlineCacheForcedFallback =
+            OfflineCacheStorageService.isForcedFallback() || bg.forcedFallback;
+        await refreshOfflineCacheSize();
+
+        if (selectedBackend === "indexeddb" && effectiveMemory) {
+            setOfflineCacheBackendSelect("memory");
+            NotyService.notyWarning(i18n.getMessage("offline_cache_indexeddb_unavailable_warning"));
+            return false;
+        }
+        return true;
+    };
+
     const save = async () => {
         lockSaveButton = true;
         logger.log("extendedSettings", extendedSettings);
-        for (const key of Object.keys(extendedSettings)) {
-            const settingId = Number(key) as keyof ExtendedSettingsForm;
-            await ExtensionSettingsService.updatePartialExtensionSettings(settingId, extendedSettings[settingId]);
-        }
-        await ConsoleLoggingService.setLogLevel(extendedSettings[ExtensionSettingsOptions.logLevel]);
+        try {
+            for (const key of Object.keys(extendedSettings)) {
+                const settingId = Number(key) as keyof ExtendedSettingsForm;
+                await ExtensionSettingsService.updatePartialExtensionSettings(settingId, extendedSettings[settingId]);
+            }
+            await ConsoleLoggingService.setLogLevel(extendedSettings[ExtensionSettingsOptions.logLevel]);
 
-        NotyService.notySuccess(i18n.getMessage('settings_updated_successfully'));
-        lockSaveButton = false;
-    }
+            const offlineCacheApplied = await applyOfflineCacheStorageBackend(
+                offlineCacheBackendSelectValue.value as OfflineCacheStorageBackend
+            );
+            if (offlineCacheApplied) {
+                NotyService.notySuccess(i18n.getMessage("settings_updated_successfully"));
+            }
+        } catch (e) {
+            logger.error(e);
+            NotyService.notyError(i18n.getMessage("unknown_error"));
+        } finally {
+            lockSaveButton = false;
+        }
+    };
 
     onMount(() => {
         ExtensionUnlockService.isSetupDone().then(async (isSetupDone) => {
@@ -218,6 +289,18 @@
                         label: logLevelOptions[logLevelValue],
                     };
 
+                    const offlineCacheBackendValue = (
+                        await ExtensionSettingsService.getPartialExtensionSettings(
+                            ExtensionSettingsOptions.offlineCacheStorageBackend,
+                            true
+                        )
+                    ) ?? OfflineCacheStorageService.DEFAULT_BACKEND;
+                    setOfflineCacheBackendSelect(offlineCacheBackendValue);
+
+                    await CustomStorageService.ensureExtensionPassmanClientPersistenceService(offlineCacheBackendValue);
+                    syncOfflineCacheStatus();
+                    // Reflect forced fallback in the select if settings were auto-updated
+                    setOfflineCacheBackendSelect(OfflineCacheStorageService.getPreferred());
                     await refreshOfflineCacheSize();
                 } else {
                     push('/unlock');
@@ -355,6 +438,41 @@
 
         <h3 class="text-lg font-semibold">{i18n.getMessage('offline_cache')}</h3>
         <p class="text-xs text-gray-500">{i18n.getMessage('offline_cache_description')}</p>
+
+        <div class="mt-2">
+            <label for="offlineCacheStorageBackend"
+                   class="text-sm font-medium text-primary-light-text dark:text-primary-dark-text block mb-2">
+                {i18n.getMessage('offline_cache_storage_backend')}
+            </label>
+            <div class="my-2">
+                <Select
+                    multiple={false}
+                    clearable={false}
+                    searchable={false}
+                    showChevron={true}
+                    label="label"
+                    itemId="value"
+                    items={offlineCacheBackendItems}
+                    bind:value={offlineCacheBackendSelectValue}
+                    id="offlineCacheStorageBackend"
+                    --height="35px"
+                    --font-size="14px"
+                    containerStyles="height: 35px;"
+                />
+            </div>
+            <p class="description-text pl-0!">{i18n.getMessage('offline_cache_storage_backend_description')}</p>
+        </div>
+
+        {#if offlineCacheEffective === 'memory'}
+            <div class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100">
+                {#if offlineCacheForcedFallback}
+                    <p>{i18n.getMessage('offline_cache_forced_fallback_notice')}</p>
+                {:else}
+                    <p>{i18n.getMessage('offline_cache_memory_mode_notice')}</p>
+                {/if}
+            </div>
+        {/if}
+
         {#if offlineCacheSizeLoading}
             <p class="text-sm text-gray-500">{i18n.getMessage('offline_cache_size_loading')}</p>
         {:else if offlineCacheSizeError}
@@ -367,6 +485,9 @@
                     String(offlineCacheSize.vaultCount),
                 ])}
             </p>
+            {#if offlineCacheEffective === 'memory'}
+                <p class="text-xs text-gray-500">{i18n.getMessage('offline_cache_size_memory_note')}</p>
+            {/if}
         {/if}
         <OnClickButton
             callback={clearOfflineCache}

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -18,7 +18,8 @@
     import NotyService from "~/services/frontend/NotyService";
     import packageJson from "../../../package.json";
     import { i18n } from "~/lib/i18n";
-    import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCachePersistenceService from "~/services/OfflineCachePersistenceService";
+    import PassmanClientService from "~/services/PassmanClientService";
     import OfflineCacheStorageService, {
         type OfflineCacheStorageBackend,
     } from "~/services/OfflineCacheStorageService";
@@ -166,7 +167,7 @@
         offlineCacheSizeLoading = true;
         offlineCacheSizeError = false;
         try {
-            offlineCacheSize = await CustomStorageService.estimateOfflineModelStoreSize();
+            offlineCacheSize = await OfflineCachePersistenceService.estimateSize();
         } catch (e) {
             logger.error(e);
             offlineCacheSize = null;
@@ -182,7 +183,7 @@
         }
         clearingOfflineCache = true;
         try {
-            await CustomStorageService.clearOfflineModelStore();
+            await OfflineCachePersistenceService.clear();
             NotyService.notySuccess(i18n.getMessage('offline_cache_cleared_successfully'));
             await refreshOfflineCacheSize();
         } catch (e) {
@@ -200,7 +201,8 @@
     const applyOfflineCacheStorageBackend = async (
         selectedBackend: OfflineCacheStorageBackend
     ): Promise<boolean> => {
-        await CustomStorageService.recreateExtensionPassmanClientPersistenceService(selectedBackend);
+        PassmanClientService.invalidatePassmanClients();
+        await OfflineCachePersistenceService.recreate(selectedBackend);
         const bg = await sendMessage("recreateOfflineCachePersistence", { preferred: selectedBackend });
         syncOfflineCacheStatus();
 
@@ -297,7 +299,7 @@
                     ) ?? OfflineCacheStorageService.DEFAULT_BACKEND;
                     setOfflineCacheBackendSelect(offlineCacheBackendValue);
 
-                    await CustomStorageService.ensureExtensionPassmanClientPersistenceService(offlineCacheBackendValue);
+                    await OfflineCachePersistenceService.get(offlineCacheBackendValue);
                     syncOfflineCacheStatus();
                     // Reflect forced fallback in the select if settings were auto-updated
                     setOfflineCacheBackendSelect(OfflineCacheStorageService.getPreferred());

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -472,6 +472,9 @@
                 {:else}
                     <p>{i18n.getMessage('offline_cache_memory_mode_notice')}</p>
                 {/if}
+                <p class="text-xs leading-relaxed text-amber-800 mt-1">
+                    * {i18n.getMessage('experimental')}
+                </p>
             </div>
         {/if}
 

--- a/src/spa_components/Settings/NextcloudServerSetup.svelte
+++ b/src/spa_components/Settings/NextcloudServerSetup.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onMount } from "svelte";
     import NextcloudServerSettings from "~/spa_components/Settings/NextcloudServerSettings.svelte";
-    import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCachePersistenceService from "~/services/OfflineCachePersistenceService";
     import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
     import { i18n } from "~/lib/i18n";
     import passmanBlueWhiteImage from "~/assets/images/passman-blue-white.svg";
@@ -12,7 +12,7 @@
     let showOfflineCacheFallbackNotice = $state(false);
 
     onMount(() => {
-        void CustomStorageService.ensureExtensionPassmanClientPersistenceService()
+        void OfflineCachePersistenceService.get()
             .then(() => {
                 showOfflineCacheFallbackNotice = !OfflineCacheStorageService.isNativeAvailable();
             })

--- a/src/spa_components/Settings/NextcloudServerSetup.svelte
+++ b/src/spa_components/Settings/NextcloudServerSetup.svelte
@@ -42,9 +42,14 @@
             <div class="mb-4 w-full rounded-lg border border-amber-200/80 bg-amber-50/90 px-3 py-2.5 text-left">
                 <div class="flex gap-2.5">
                     <Icon data={warning} scale={1.0} class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"/>
-                    <p class="text-xs leading-relaxed text-amber-800">
-                        {i18n.getMessage('setup_offline_cache_fallback_notice')}
-                    </p>
+                    <div class="text-xs leading-relaxed text-amber-800">
+                        <p>
+                            {i18n.getMessage('setup_offline_cache_fallback_notice')}
+                        </p>
+                        <p class="mt-1">
+                            * {i18n.getMessage('experimental')}
+                        </p>
+                    </div>
                 </div>
             </div>
         {/if}

--- a/src/spa_components/Settings/NextcloudServerSetup.svelte
+++ b/src/spa_components/Settings/NextcloudServerSetup.svelte
@@ -1,8 +1,25 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import NextcloudServerSettings from "~/spa_components/Settings/NextcloudServerSettings.svelte";
+    import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
     import { i18n } from "~/lib/i18n";
     import passmanBlueWhiteImage from "~/assets/images/passman-blue-white.svg";
     import passmanImage from "~/assets/images/passman.svg";
+    import Icon from "svelte-awesome/components/Icon.svelte";
+    import { warning } from "svelte-awesome/icons";
+
+    let showOfflineCacheFallbackNotice = $state(false);
+
+    onMount(() => {
+        void CustomStorageService.ensureExtensionPassmanClientPersistenceService()
+            .then(() => {
+                showOfflineCacheFallbackNotice = !OfflineCacheStorageService.isNativeAvailable();
+            })
+            .catch(() => {
+                showOfflineCacheFallbackNotice = false;
+            });
+    });
 </script>
 
 <div class="flex h-full flex-col items-center px-6 py-8">
@@ -20,6 +37,17 @@
                 {i18n.getMessage('setup_server_step_intro')}
             </p>
         </div>
+
+        {#if showOfflineCacheFallbackNotice}
+            <div class="mb-4 w-full rounded-lg border border-amber-200/80 bg-amber-50/90 px-3 py-2.5 text-left">
+                <div class="flex gap-2.5">
+                    <Icon data={warning} scale={1.0} class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"/>
+                    <p class="text-xs leading-relaxed text-amber-800">
+                        {i18n.getMessage('setup_offline_cache_fallback_notice')}
+                    </p>
+                </div>
+            </div>
+        {/if}
 
         <div class="w-full">
             <NextcloudServerSettings/>

--- a/src/spa_components/Setup.svelte
+++ b/src/spa_components/Setup.svelte
@@ -5,7 +5,7 @@
     import CustomInputField from "~/spa_partials/FormElements/CustomInputField.svelte";
     import ExtensionUnlockService from "~/services/ExtensionUnlockService";
     import LegacySettingsMigrationService from "~/services/LegacySettingsMigrationService";
-    import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCachePersistenceService from "~/services/OfflineCachePersistenceService";
     import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
     import { sendMessage } from "@/entrypoints/background/messaging";
     // @ts-expect-error
@@ -26,7 +26,7 @@
 
     const ensurePersistenceService = async (syncBackground = false) => {
         try {
-            await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+            await OfflineCachePersistenceService.get();
             if (syncBackground) {
                 // probe/init background persistence after unlock password exists
                 await sendMessage("recreateOfflineCachePersistence", {});

--- a/src/spa_components/Setup.svelte
+++ b/src/spa_components/Setup.svelte
@@ -5,12 +5,17 @@
     import CustomInputField from "~/spa_partials/FormElements/CustomInputField.svelte";
     import ExtensionUnlockService from "~/services/ExtensionUnlockService";
     import LegacySettingsMigrationService from "~/services/LegacySettingsMigrationService";
+    import CustomStorageService from "~/services/CustomStorageService";
+    import OfflineCacheStorageService from "~/services/OfflineCacheStorageService";
+    import { sendMessage } from "@/entrypoints/background/messaging";
     // @ts-expect-error
     import { push } from "~/Router.svelte";
     import { i18n } from "~/lib/i18n";
     import browser from "webextension-polyfill";
     import passmanBlueWhiteImage from "~/assets/images/passman-blue-white.svg";
     import passmanImage from "~/assets/images/passman.svg";
+    import Icon from "svelte-awesome/components/Icon.svelte";
+    import { warning } from "svelte-awesome/icons";
 
     export let params: { isInPopup: string };
 
@@ -18,6 +23,17 @@
     let isExtensionUnlocked = false;
     let processNewUnlockPassword = false;
     let showLegacyImport = false;
+
+    const ensurePersistenceService = async (syncBackground = false) => {
+        try {
+            await CustomStorageService.ensureExtensionPassmanClientPersistenceService();
+            if (syncBackground) {
+                // probe/init background persistence after unlock password exists
+                await sendMessage("recreateOfflineCachePersistence", {});
+            }
+        } catch {
+        }
+    };
 
     onMount(() => {
         // Popup only offers "open options"; migrate UI lives on the options setup screen.
@@ -27,12 +43,20 @@
         LegacySettingsMigrationService.hasLegacyData().then((hasLegacy) => {
             showLegacyImport = hasLegacy;
         });
+        void ExtensionUnlockService.isUnlocked().then(async (unlocked) => {
+            if (unlocked) {
+                // do not ask to setup a new unlock password if the extension is already unlocked
+                isExtensionUnlocked = true;
+                await ensurePersistenceService(false);
+            }
+        });
     });
 
     async function setUnlockPassword() {
         processNewUnlockPassword = true;
         await ExtensionUnlockService.setUpExtensionPassword(newExtensionUnlockPassword);
         isExtensionUnlocked = true;
+        await ensurePersistenceService(true);
         processNewUnlockPassword = false;
         push('/setup/server');
     }
@@ -121,9 +145,7 @@
 
         <div class="mt-5 w-full rounded-lg border border-amber-200/80 bg-amber-50/90 px-3 py-2.5 text-left">
             <div class="flex gap-2.5">
-                <svg class="mt-0.5 h-4 w-4 shrink-0 text-amber-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                    <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
-                </svg>
+                <Icon data={warning} scale={1.0} class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"/>
                 <p class="text-xs leading-relaxed text-amber-800">
                     {@html i18n.getMessage('setup_dev_warning', [
                         '<br>',

--- a/src/spa_partials/Toaster.svelte
+++ b/src/spa_partials/Toaster.svelte
@@ -14,7 +14,7 @@
         message: string;
         title?: string;
         type?: ToastType;
-        duration?: number;  // milliseconds, default 5000
+        duration?: number;  // milliseconds, default 5000; use `0` for a pinned (sticky) toast
         showIcon?: boolean; // defaults to true
     };
 
@@ -31,7 +31,8 @@
 
         return toaster.addToast({
             data: toastData,
-            closeDelay: data.duration || defaultCloseDelay,
+            // nullish: duration 0 (pinned) must stay sticky (|| would fall back to default)
+            closeDelay: data.duration ?? defaultCloseDelay,
         });
     };
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.wxt/tsconfig.json",
   "compilerOptions": {
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "types": ["bun"],
   }
 }


### PR DESCRIPTION
- add an offline-cache backend choice: persistent IndexedDB (default) or volatile in-memory store when native IndexedDB is blocked (e.g. Firefox “Never remember history” / [#380](https://github.com/nextcloud/passman-webextension/issues/380)).
- probe IndexedDB during setup/init, auto-fall back to memory, surface amber banners and sticky toasts (including quota / mutation-denied soft-fails).
- extended settings to view/switch the cache backend
- (simple but new) unit tests + CI test step for the new services


closes #380 
