### PR TITLE
Extension auto-unlock feature

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "passman-webextension",
       "dependencies": {
         "@tanstack/svelte-virtual": "^3.13.35",
-        "js-sha512": "^0.9.0",
         "regexparam": "^3.0.0",
         "svelte": "^5.56.8",
         "svelte-preprocess": "^5.1.4",
@@ -857,8 +856,6 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-base64": ["js-base64@3.9.2", "", {}, "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA=="],
-
-    "js-sha512": ["js-sha512@0.9.0", "", {}, "sha512-mirki9WS/SUahm+1TbAPkqvbCiCfOAAsyXeHxK1UkullnJVVqoJG2pL9ObvT05CN+tM7fxhfYm0NbXn+1hWoZg=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@tanstack/svelte-virtual": "^3.13.35",
-    "js-sha512": "^0.9.0",
     "regexparam": "^3.0.0",
     "svelte": "^5.56.8",
     "svelte-preprocess": "^5.1.4"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1249,6 +1249,30 @@
     "message": "Could not change the unlock password. Check the current password and try again.",
     "description": "Error when changing the extension unlock password fails"
   },
+  "enable_auto_unlock": {
+    "message": "Auto-unlock on browser start",
+    "description": "Checkbox label to enable unlocking the extension without entering the password automatically when the browser starts"
+  },
+  "enable_auto_unlock_description": {
+    "message": "Keeps the extension unlocked across browser restarts without storing your unlock password. Anyone who can run code in this extension, or read this browser profile from disk, can then access your vault data without the password. It is like an OS “stay signed in” option.",
+    "description": "Trade-off hint under the auto-unlock checkbox"
+  },
+  "enable_auto_unlock_lock_note": {
+    "message": "Locking the extension turns auto-unlock off. Re-enable it here afterwards.",
+    "description": "Note that an explicit lock permanently disables auto-unlock until the user re-enables it"
+  },
+  "enable_auto_unlock_local_fallback_notice": {
+    "message": "IndexedDB is not usable in this browser profile, so the auto-unlock key is stored in extension local storage. That is weaker: anyone who can read the extension storage can unlock without your password.",
+    "description": "Amber notice when auto-unlock falls back from IndexedDB to browser.storage.local"
+  },
+  "auto_unlock_enable_failed": {
+    "message": "Could not enable auto-unlock. Unlock or restart the extension and try again.",
+    "description": "Error toast when enabling auto-unlock fails"
+  },
+  "auto_unlock_disable_failed": {
+    "message": "Could not disable auto-unlock.",
+    "description": "Error toast when disabling auto-unlock fails"
+  },
   "migrate_legacy_title": {
     "message": "Import previous settings",
     "description": "Title for the legacy MV2 settings import block on the setup screen"

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,4 +1,5 @@
 import ExtensionUnlockService from "@/services/ExtensionUnlockService";
+import ExtensionAutoUnlockService from "@/services/ExtensionAutoUnlockService";
 import { ExtensionBadgeService } from "@/services/backend/ExtensionBadgeService";
 import ContextMenuService from "@/services/backend/ContextMenuService";
 import ExtensionMigrationService from "@/services/ExtensionMigrationService";
@@ -54,11 +55,6 @@ export default defineBackground(() => {
         });
     });
 
-    // Catch upgrades that missed onInstalled
-    ExtensionMigrationService.runOnStartup().catch((e) => {
-        logger.warn('[migration] runOnStartup failed', e);
-    });
-
     browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
         ExtensionUnlockService.isUnlocked().then(async (isUnlocked) => {
             if (isUnlocked) {
@@ -88,5 +84,15 @@ export default defineBackground(() => {
 
     executeOnMessageListenerRegistration();
 
-    ContextMenuService.reInit();
+    // Ordered execution to run on each background script start
+    ExtensionMigrationService.runOnBackgroundScriptStart().catch((e) => {
+        logger.warn('[migration] runOnBackgroundScriptStart failed', e);
+    }).finally(async () => {
+        // the immediate call covers extension reloads and updates, where the session storage is cleared
+        await ExtensionAutoUnlockService.tryAutoUnlock().catch((e) => {
+            logger.warn('tryAutoUnlock failed', e);
+        });
+
+        ContextMenuService.reInit();
+    });
 });

--- a/src/lib/auto-unlock-key-store.ts
+++ b/src/lib/auto-unlock-key-store.ts
@@ -1,0 +1,196 @@
+import CustomStorageService from "@/services/CustomStorageService";
+import { logger } from "@/services/ConsoleLoggingService";
+
+/**
+ * Where the auto-unlock key is kept.
+ * - `indexeddb`: the preferred backend. The key is held as a non-extractable {@link CryptoKey} object,
+ *   so its raw bytes are never observable from JavaScript, a storage dump, an export or a sync.
+ * - `local`: fallback for profiles that block IndexedDB (for example Firefox "Never remember history").
+ *   `browser.storage.local` can only hold JSON, so the raw key bytes have to be stored next to the
+ *   wrapped storage key. Anyone who can read the extension storage can then unwrap the storage key.
+ */
+export type AutoUnlockKeyStorageBackend = "indexeddb" | "local";
+
+export interface AutoUnlockKeyHandle {
+    key: CryptoKey;
+    backend: AutoUnlockKeyStorageBackend;
+}
+
+const DB_NAME = "passman-auto-unlock";
+const DB_VERSION = 1;
+const OBJECT_STORE_NAME = "keys";
+const KEY_RECORD_ID = "autoUnlockKey";
+const PROBE_RECORD_ID = "autoUnlockKeyProbe";
+const LOCAL_FALLBACK_ACCESS_KEY = "autoUnlockKeyFallback";
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+    });
+}
+
+function transactionToPromise(transaction: IDBTransaction): Promise<void> {
+    return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB transaction failed"));
+        transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB transaction aborted"));
+    });
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+    const factory = globalThis.indexedDB;
+    if (!factory) {
+        return Promise.reject(new Error("IndexedDB is not available"));
+    }
+
+    return new Promise((resolve, reject) => {
+        const request = factory.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            if (!request.result.objectStoreNames.contains(OBJECT_STORE_NAME)) {
+                request.result.createObjectStore(OBJECT_STORE_NAME);
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB"));
+        request.onblocked = () => reject(new Error("Opening IndexedDB was blocked by an open connection"));
+    });
+}
+
+async function putIntoIndexedDb(recordId: string, key: CryptoKey): Promise<void> {
+    const db = await openDatabase();
+    try {
+        const transaction = db.transaction(OBJECT_STORE_NAME, "readwrite");
+        transaction.objectStore(OBJECT_STORE_NAME).put(key, recordId);
+        await transactionToPromise(transaction);
+    } finally {
+        db.close();
+    }
+}
+
+async function getFromIndexedDb(recordId: string): Promise<CryptoKey | undefined> {
+    const db = await openDatabase();
+    try {
+        const transaction = db.transaction(OBJECT_STORE_NAME, "readonly");
+        const record = await requestToPromise(transaction.objectStore(OBJECT_STORE_NAME).get(recordId));
+        return (record as CryptoKey | undefined) ?? undefined;
+    } finally {
+        db.close();
+    }
+}
+
+async function deleteFromIndexedDb(recordId: string): Promise<void> {
+    const db = await openDatabase();
+    try {
+        const transaction = db.transaction(OBJECT_STORE_NAME, "readwrite");
+        transaction.objectStore(OBJECT_STORE_NAME).delete(recordId);
+        await transactionToPromise(transaction);
+    } finally {
+        db.close();
+    }
+}
+
+/**
+ * Generate an auto-unlock key. It can only wrap and unwrap the storage key, never encrypt arbitrary data.
+ * @param extractable Only the local storage fallback needs the raw bytes
+ */
+function generateKey(extractable: boolean): Promise<CryptoKey> {
+    return crypto.subtle.generateKey(
+        { name: "AES-GCM", length: 256 },
+        extractable,
+        ["wrapKey", "unwrapKey"]
+    );
+}
+
+function getLocalStorage() {
+    return CustomStorageService.getUnsafeLocalStorage();
+}
+
+async function loadFromLocalStorage(): Promise<CryptoKey | undefined> {
+    const rawKey = await getLocalStorage().get<string>(LOCAL_FALLBACK_ACCESS_KEY);
+    if (!rawKey) {
+        return undefined;
+    }
+
+    return await crypto.subtle.importKey(
+        "raw",
+        Uint8Array.from(atob(rawKey), c => c.charCodeAt(0)),
+        { name: "AES-GCM" },
+        true,
+        ["wrapKey", "unwrapKey"]
+    );
+}
+
+async function storeInLocalStorage(key: CryptoKey): Promise<void> {
+    const exported = await crypto.subtle.exportKey("raw", key);
+    await getLocalStorage().set(
+        LOCAL_FALLBACK_ACCESS_KEY,
+        btoa(String.fromCharCode(...new Uint8Array(exported)))
+    );
+}
+
+/**
+ * Report the backend an {@link createAutoUnlockKey} call would use right now.
+ * Storing a throwaway key is the only reliable check, as blocked profiles fail on write rather than on open.
+ */
+export async function probeAutoUnlockKeyStorageBackend(): Promise<AutoUnlockKeyStorageBackend> {
+    try {
+        await putIntoIndexedDb(PROBE_RECORD_ID, await generateKey(false));
+        await deleteFromIndexedDb(PROBE_RECORD_ID);
+        return "indexeddb";
+    } catch (e) {
+        logger.warn("IndexedDB is not usable for the auto-unlock key", e);
+        return "local";
+    }
+}
+
+/**
+ * Create and persist a fresh auto-unlock key, replacing any previously stored one.
+ */
+export async function createAutoUnlockKey(): Promise<AutoUnlockKeyHandle> {
+    await deleteAutoUnlockKey();
+
+    if (await probeAutoUnlockKeyStorageBackend() === "indexeddb") {
+        try {
+            const key = await generateKey(false);
+            await putIntoIndexedDb(KEY_RECORD_ID, key);
+            return { key, backend: "indexeddb" };
+        } catch (e) {
+            logger.warn("Failed to store the auto-unlock key in IndexedDB", e);
+        }
+    }
+
+    const key = await generateKey(true);
+    await storeInLocalStorage(key);
+    return { key, backend: "local" };
+}
+
+/**
+ * Load the persisted auto-unlock key, or undefined if none is stored.
+ */
+export async function loadAutoUnlockKey(): Promise<AutoUnlockKeyHandle | undefined> {
+    try {
+        const key = await getFromIndexedDb(KEY_RECORD_ID);
+        if (key) {
+            return { key, backend: "indexeddb" };
+        }
+    } catch (e) {
+        logger.warn("Failed to read the auto-unlock key from IndexedDB", e);
+    }
+
+    const fallbackKey = await loadFromLocalStorage();
+    return fallbackKey ? { key: fallbackKey, backend: "local" } : undefined;
+}
+
+/**
+ * Remove the auto-unlock key from both backends, so a backend switch cannot leave a usable key behind.
+ */
+export async function deleteAutoUnlockKey(): Promise<void> {
+    try {
+        await deleteFromIndexedDb(KEY_RECORD_ID);
+    } catch (e) {
+        logger.warn("Failed to remove the auto-unlock key from IndexedDB", e);
+    }
+
+    await getLocalStorage().remove(LOCAL_FALLBACK_ACCESS_KEY);
+}

--- a/src/lib/secure-storage.ts
+++ b/src/lib/secure-storage.ts
@@ -9,21 +9,19 @@ export class SecureStorage extends Storage {
     private static readonly SALT_LENGTH = 16; // 128 bits = 16 bytes
     private static readonly ENCRYPTED_STORAGE_KEY_KEY = 'encryptedStorageKey';
 
-    constructor(area: "local" | "sync" | "session" = "local", private secret?: string, namespace?: string) {
+    constructor(area: "local" | "sync" | "session" = "local", namespace?: string) {
         super(area, namespace);
     }
 
     /**
-     * Set password / secret.
-     * Reset internal cached key.
+     * Set the storage key used for all data operations of this instance.
      */
-    public setPassword(secret?: string) {
-        this.secret = secret;
-        this.cryptoKey = null;
+    public setStorageKey(storageKey?: CryptoKey) {
+        this.cryptoKey = storageKey ?? null;
     }
 
-    get isPasswordSet(): boolean {
-        return this.secret !== undefined;
+    get isStorageKeySet(): boolean {
+        return this.cryptoKey !== null;
     }
 
     /**
@@ -48,7 +46,7 @@ export class SecureStorage extends Storage {
      * @param salt The salt to use for key derivation
      * @returns A CryptoKey derived from the password
      */
-    private async deriveKeyFromPassword(password: string, salt: Uint8Array): Promise<CryptoKey> {
+    private static async deriveKeyFromPassword(password: string, salt: Uint8Array): Promise<CryptoKey> {
         const passwordKey = await crypto.subtle.importKey(
             "raw",
             new TextEncoder().encode(password),
@@ -80,11 +78,11 @@ export class SecureStorage extends Storage {
      * @param password The password to encrypt with
      * @returns An object containing the encrypted key, IV, and salt
      */
-    public async encryptStorageKey(storageKey: CryptoKey, password: string): Promise<{ encryptedKey: string; iv: number[]; salt: number[] }> {
+    public static async encryptStorageKey(storageKey: CryptoKey, password: string): Promise<{ encryptedKey: string; iv: number[]; salt: number[] }> {
         const salt = crypto.getRandomValues(new Uint8Array(SecureStorage.SALT_LENGTH));
         const iv = crypto.getRandomValues(new Uint8Array(12)); // 96 bits for AES-GCM
 
-        const derivedKey = await this.deriveKeyFromPassword(password, salt);
+        const derivedKey = await SecureStorage.deriveKeyFromPassword(password, salt);
         const exportedKey = await crypto.subtle.exportKey("raw", storageKey);
         const encrypted = await crypto.subtle.encrypt(
             { name: "AES-GCM", iv },
@@ -104,7 +102,7 @@ export class SecureStorage extends Storage {
      * @param password The password to decrypt with
      * @returns The decrypted storage key as CryptoKey, or null if decryption fails
      */
-    public async decryptStorageKey(password: string): Promise<CryptoKey | null> {
+    public static async decryptStorageKey(password: string): Promise<CryptoKey | null> {
         try {
             const unsafeStorage = new Storage("local");
             const encryptedData = await unsafeStorage.get<{ encryptedKey: string; iv: number[]; salt: number[] }>(
@@ -119,7 +117,7 @@ export class SecureStorage extends Storage {
             const iv = new Uint8Array(encryptedData.iv);
             const encryptedBytes = Uint8Array.from(atob(encryptedData.encryptedKey), c => c.charCodeAt(0));
 
-            const derivedKey = await this.deriveKeyFromPassword(password, salt);
+            const derivedKey = await SecureStorage.deriveKeyFromPassword(password, salt);
             const decrypted = await crypto.subtle.decrypt(
                 { name: "AES-GCM", iv },
                 derivedKey,
@@ -159,30 +157,44 @@ export class SecureStorage extends Storage {
     }
 
     /**
-     * Get the encryption key for data operations.
-     * If no key is cached, decrypts the stored storage key using the password.
+     * Export a storage key so it can be handed around without exposing the unlock password.
+     * @param storageKey An extractable storage key
      */
-    private async getEncryptionKey(): Promise<CryptoKey> {
-        if (this.cryptoKey) return this.cryptoKey;
+    public static async exportStorageKeyBase64(storageKey: CryptoKey): Promise<string> {
+        const exported = await crypto.subtle.exportKey("raw", storageKey);
+        return btoa(String.fromCharCode(...new Uint8Array(exported)));
+    }
 
-        if (!this.secret) {
-            throw new Error("Password must be set before getting encryption key");
+    /**
+     * Import a storage key previously exported by {@link exportStorageKeyBase64}.
+     * Imported as extractable so it can be re-encrypted when changing passwords.
+     */
+    public static async importStorageKeyBase64(rawStorageKey: string): Promise<CryptoKey> {
+        const keyMaterial = Uint8Array.from(atob(rawStorageKey), c => c.charCodeAt(0));
+        return await crypto.subtle.importKey(
+            "raw",
+            keyMaterial,
+            { name: "AES-GCM" },
+            true,
+            ["encrypt", "decrypt"]
+        );
+    }
+
+    /**
+     * Get the encryption key for data operations.
+     */
+    private getEncryptionKey(): CryptoKey {
+        if (!this.cryptoKey) {
+            throw new Error("Storage key must be set before getting encryption key");
         }
 
-        // Try to decrypt the stored storage key
-        const storageKey = await this.decryptStorageKey(this.secret);
-        if (!storageKey) {
-            throw new Error("Failed to decrypt storage key. The password may be incorrect or no storage key exists.");
-        }
-
-        this.cryptoKey = storageKey;
         return this.cryptoKey;
     }
 
     async set(key: string, value: any) {
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const encoded = new TextEncoder().encode(JSON.stringify(value));
-        const cryptoKey = await this.getEncryptionKey();
+        const cryptoKey = this.getEncryptionKey();
         const cipher = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, encoded);
         const data = { iv: Array.from(iv), value: btoa(String.fromCharCode(...new Uint8Array(cipher))) };
         await super.set(key, data);
@@ -197,7 +209,7 @@ export class SecureStorage extends Storage {
         if (!data) return undefined;
         const iv = new Uint8Array(data.iv);
         const bytes = Uint8Array.from(atob(data.value), c => c.charCodeAt(0));
-        const cryptoKey = await this.getEncryptionKey();
+        const cryptoKey = this.getEncryptionKey();
         const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, cryptoKey, bytes);
         return JSON.parse(new TextDecoder().decode(decrypted));
     }

--- a/src/services/CustomStorageService.ts
+++ b/src/services/CustomStorageService.ts
@@ -30,18 +30,19 @@ export default class CustomStorageService {
 
     /**
      * Returns an unlocked secure storage instance, if the extension is successfully unlocked.
-     * If it is not successfully unlocked, it returns a secure storage without password.
+     * If it is not successfully unlocked, it returns a secure storage without storage key.
      */
     public static async getSecureStorage() {
         if (!this.secureStorage) {
             this.secureStorage = new SecureStorage();
             this.secureStorage.setNamespace(DEFAULT_STORAGE_NAMESPACE);
         }
-        if (!this.secureStorage.isPasswordSet) {
-            const extensionUnlockPassword = await this.getSessionStorage().get(ExtensionUnlockService.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY);
-            if (extensionUnlockPassword) {
-                this.secureStorage.setPassword(
-                    extensionUnlockPassword
+        if (!this.secureStorage.isStorageKeySet) {
+            const rawStorageKey = await this.getSessionStorage()
+                .get<string>(ExtensionUnlockService.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY);
+            if (rawStorageKey) {
+                this.secureStorage.setStorageKey(
+                    await SecureStorage.importStorageKeyBase64(rawStorageKey)
                 );
             }
         }

--- a/src/services/ExtensionAutoUnlockService.ts
+++ b/src/services/ExtensionAutoUnlockService.ts
@@ -1,0 +1,147 @@
+import CustomStorageService from "./CustomStorageService";
+import ExtensionUnlockService from "./ExtensionUnlockService";
+import { SecureStorage } from "@/lib/secure-storage";
+import {
+    type AutoUnlockKeyStorageBackend,
+    createAutoUnlockKey,
+    deleteAutoUnlockKey,
+    loadAutoUnlockKey,
+    probeAutoUnlockKeyStorageBackend,
+} from "@/lib/auto-unlock-key-store";
+import { logger } from "./ConsoleLoggingService";
+
+/**
+ * Optional feature that unlocks the extension on browser start without asking for the unlock password.
+ *
+ * The storage key gets a second, independent wrapping under a random auto-unlock key.
+ * No key derivation is involved here, as the auto-unlock key has strong entropy.
+ * The unlock password is not part of this at all and stays unrecoverable.
+ *
+ * This is a convenience versus exposure trade: whoever can run code in the extension origin, or read the
+ * auto-unlock key from the browser profile, can unwrap the (SecureStorage) storage key without knowing the password.
+ * If that happens, it would leak everything, since the Nextcloud user and vault keys are stored in the SecureStorage.
+ */
+export default class ExtensionAutoUnlockService {
+    public static readonly WRAPPED_STORAGE_KEY_UNSAFE_ACCESS_KEY = 'autoUnlockWrappedStorageKey';
+    private static readonly AES_GCM_IV_LENGTH = 12; // 96 bits, the nonce size AES-GCM is specified for
+
+    private static autoUnlockAttempt: Promise<boolean> | undefined;
+
+    /**
+     * Report which backend would hold the auto-unlock key, so the settings UI can warn about the
+     * weaker local storage fallback before the user enables the feature.
+     */
+    public static getStorageBackend(): Promise<AutoUnlockKeyStorageBackend> {
+        return probeAutoUnlockKeyStorageBackend();
+    }
+
+    public static async isEnabled(): Promise<boolean> {
+        if (!await this.getWrappedStorageKey()) {
+            return false;
+        }
+
+        return await loadAutoUnlockKey() !== undefined;
+    }
+
+    /**
+     * Arm auto-unlock for the currently unlocked storage key.
+     * A fresh auto-unlock key is generated every time, so a previously stored one can never be reused.
+     * @returns false if the extension is locked
+     */
+    public static async enable(): Promise<boolean> {
+        const storageKey = await this.getSessionStorageKey();
+        if (!storageKey) {
+            logger.warn("Cannot enable auto-unlock while the extension is locked");
+            return false;
+        }
+
+        const { key: autoUnlockKey } = await createAutoUnlockKey();
+        const iv = crypto.getRandomValues(new Uint8Array(this.AES_GCM_IV_LENGTH));
+        const wrappedStorageKey = await crypto.subtle.wrapKey(
+            "raw",
+            storageKey,
+            autoUnlockKey,
+            { name: "AES-GCM", iv }
+        );
+
+        await CustomStorageService.getUnsafeLocalStorage().set(this.WRAPPED_STORAGE_KEY_UNSAFE_ACCESS_KEY, {
+            iv: Array.from(iv),
+            value: btoa(String.fromCharCode(...new Uint8Array(wrappedStorageKey))),
+        });
+
+        return true;
+    }
+
+    /**
+     * Disarm auto-unlock by dropping the auto-unlock key and the wrapped storage key.
+     */
+    public static async disable(): Promise<void> {
+        await deleteAutoUnlockKey();
+        await CustomStorageService.getUnsafeLocalStorage().remove(this.WRAPPED_STORAGE_KEY_UNSAFE_ACCESS_KEY);
+    }
+
+    /**
+     * Unlock the extension from the stored auto-unlock key, if the feature is armed.
+     * Any unusable state disarms the feature instead of leaving a half broken setup behind.
+     * Concurrent attempts share one run.
+     * @returns true if the extension is unlocked afterwards
+     */
+    public static tryAutoUnlock(): Promise<boolean> {
+        if (!this.autoUnlockAttempt) {
+            this.autoUnlockAttempt = this.runAutoUnlock().finally(() => {
+                this.autoUnlockAttempt = undefined;
+            });
+        }
+
+        return this.autoUnlockAttempt;
+    }
+
+    private static async runAutoUnlock(): Promise<boolean> {
+        if (await ExtensionUnlockService.isUnlocked()) {
+            return true;
+        }
+
+        const wrappedStorageKey = await this.getWrappedStorageKey();
+        if (!wrappedStorageKey) {
+            return false;
+        }
+
+        const autoUnlockKey = await loadAutoUnlockKey();
+        if (!autoUnlockKey) {
+            logger.warn("A wrapped storage key exists without an auto-unlock key");
+            await this.disable();
+            return false;
+        }
+
+        try {
+            const storageKey = await crypto.subtle.unwrapKey(
+                "raw",
+                Uint8Array.from(atob(wrappedStorageKey.value), c => c.charCodeAt(0)),
+                autoUnlockKey.key,
+                { name: "AES-GCM", iv: new Uint8Array(wrappedStorageKey.iv) },
+                { name: "AES-GCM" },
+                // extractable, so it can be handed to the session and re-wrapped later
+                true,
+                ["encrypt", "decrypt"]
+            );
+            await ExtensionUnlockService.applyUnlockedStorageKey(storageKey);
+            return true;
+        } catch (e) {
+            logger.error("Failed to unwrap the storage key", e);
+            await this.disable();
+            return false;
+        }
+    }
+
+    private static getWrappedStorageKey(): Promise<{ iv: number[]; value: string } | undefined> {
+        return CustomStorageService.getUnsafeLocalStorage()
+            .get<{ iv: number[]; value: string }>(this.WRAPPED_STORAGE_KEY_UNSAFE_ACCESS_KEY);
+    }
+
+    private static async getSessionStorageKey(): Promise<CryptoKey | undefined> {
+        const rawStorageKey = await CustomStorageService.getSessionStorage()
+            .get<string>(ExtensionUnlockService.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY);
+
+        return rawStorageKey ? await SecureStorage.importStorageKeyBase64(rawStorageKey) : undefined;
+    }
+}

--- a/src/services/ExtensionMigrationService.ts
+++ b/src/services/ExtensionMigrationService.ts
@@ -13,20 +13,26 @@ export default class ExtensionMigrationService {
     private static readonly REMOVED_KEYVAL_STORE_FLAG = "migration.removedLegacyKeyvalStore";
 
     /**
+     * Flag to mark the "maybeRemoveUnlockPasswordArtifacts" migration as done.
+     */
+    private static readonly REMOVED_UNLOCK_PASSWORD_ARTIFACTS_FLAG = "migration.removedUnlockPasswordArtifacts";
+
+    /**
      * Run migrations triggered by browser.runtime.onInstalled.
      */
     public static async runOnInstalled(details: browser.Runtime.OnInstalledDetailsType): Promise<void> {
         if (details.reason === "install") {
             // Fresh install never had the legacy store; mark done so startup skips the delete.
             await this.markLegacyKeyvalStoreMigrationDone();
+            await this.markUnlockPasswordArtifactsMigrationDone();
         } else if (details.reason === "update") {
             await this.maybeRemoveLegacyKeyvalStore(details.previousVersion);
+            await this.maybeRemoveUnlockPasswordArtifacts();
         }
     }
 
     /**
      * Safety net for very important upgrades that happened before this migration existed, or if onInstalled did not run for some reason.
-     * Idempotent via {@link REMOVED_KEYVAL_STORE_FLAG}.
      */
     public static async runOnBackgroundScriptStart(): Promise<void> {
         // just a placeholder for now, no use-case for this yet
@@ -76,6 +82,41 @@ export default class ExtensionMigrationService {
 
     private static async markLegacyKeyvalStoreMigrationDone(): Promise<void> {
         await CustomStorageService.getUnsafeLocalStorage().set(this.REMOVED_KEYVAL_STORE_FLAG, true);
+    }
+
+    /**
+     * Drop the leftovers of the former password based unlock once.
+     * Since the storage key is the only secret the extension keeps after unlocking, the unsalted sha512
+     * verifier of the unlock password and the unlock password within the session storage are both obsolete.
+     * The hash especially is worth removing, as it allows cracking the unlock password offline.
+     */
+    private static async maybeRemoveUnlockPasswordArtifacts(): Promise<void> {
+        const storage = CustomStorageService.getUnsafeLocalStorage();
+        if (await storage.get<boolean>(this.REMOVED_UNLOCK_PASSWORD_ARTIFACTS_FLAG)) {
+            return;
+        }
+
+        /**
+         * Storage keys used by the password based unlock up to version 3.1.0.
+         */
+        const LEGACY_UNLOCK_PASSWORD_HASH_KEY = "extensionUnlockPasswordHash";
+        const LEGACY_UNLOCK_PASSWORD_SESSION_KEY = "extensionUnlockPassword";
+
+        try {
+            await storage.remove(LEGACY_UNLOCK_PASSWORD_HASH_KEY);
+            await CustomStorageService.getSessionStorage().remove(LEGACY_UNLOCK_PASSWORD_SESSION_KEY);
+            logger.info("[migration] Removed the unlock password hash and the session unlock password");
+        } catch (e) {
+            logger.warn("[migration] Failed to remove the former unlock password artifacts", e);
+            // Do not set the flag on failure so a later SW start can retry
+            return;
+        }
+
+        await this.markUnlockPasswordArtifactsMigrationDone();
+    }
+
+    private static async markUnlockPasswordArtifactsMigrationDone(): Promise<void> {
+        await CustomStorageService.getUnsafeLocalStorage().set(this.REMOVED_UNLOCK_PASSWORD_ARTIFACTS_FLAG, true);
     }
 
     /**

--- a/src/services/ExtensionMigrationService.ts
+++ b/src/services/ExtensionMigrationService.ts
@@ -103,7 +103,9 @@ export default class ExtensionMigrationService {
         const LEGACY_UNLOCK_PASSWORD_SESSION_KEY = "extensionUnlockPassword";
 
         try {
-            await storage.remove(LEGACY_UNLOCK_PASSWORD_HASH_KEY);
+            if (await storage.get<string>(LEGACY_UNLOCK_PASSWORD_HASH_KEY)) {
+                await storage.remove(LEGACY_UNLOCK_PASSWORD_HASH_KEY);
+            }
             await CustomStorageService.getSessionStorage().remove(LEGACY_UNLOCK_PASSWORD_SESSION_KEY);
             logger.info("[migration] Removed the unlock password hash and the session unlock password");
         } catch (e) {

--- a/src/services/ExtensionMigrationService.ts
+++ b/src/services/ExtensionMigrationService.ts
@@ -28,7 +28,7 @@ export default class ExtensionMigrationService {
      * Safety net for very important upgrades that happened before this migration existed, or if onInstalled did not run for some reason.
      * Idempotent via {@link REMOVED_KEYVAL_STORE_FLAG}.
      */
-    public static async runOnStartup(): Promise<void> {
+    public static async runOnBackgroundScriptStart(): Promise<void> {
         // just a placeholder for now, no use-case for this yet
     }
 

--- a/src/services/ExtensionUnlockService.ts
+++ b/src/services/ExtensionUnlockService.ts
@@ -1,4 +1,5 @@
 import CustomStorageService from "./CustomStorageService";
+import ExtensionAutoUnlockService from "./ExtensionAutoUnlockService";
 import ExtensionSettingsService, { ExtensionSettingsOptions } from "./ExtensionSettingsService";
 import PassmanClientService from "./PassmanClientService";
 import type Vault from "@binsky/passman-client-ts/lib/Model/Vault";
@@ -55,10 +56,12 @@ export default class ExtensionUnlockService {
 
     /**
      * Locks the extension, as well as taking care about clearing decrypted cache within the background service worker.
+     * An explicit lock also disarms auto-unlock, so it has to be re-enabled in the settings afterwards.
      * Should be called from the LockExtension MessageHandler.
      */
     public static async lock() {
         await CustomStorageService.clearSessionStorage();
+        await ExtensionAutoUnlockService.disable();
         CustomStorageService.closeSecureStorage();
         PassmanClientService.invalidatePassmanClients();
         ExtensionBadgeService.displayLockIcons();

--- a/src/services/ExtensionUnlockService.ts
+++ b/src/services/ExtensionUnlockService.ts
@@ -14,8 +14,9 @@ import { SecureStorage } from "@/lib/secure-storage";
 import ConsoleLoggingService, { logger } from "./ConsoleLoggingService";
 
 export default class ExtensionUnlockService {
-    public static readonly EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY = 'extensionUnlockPassword';
+    public static readonly EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY = 'extensionStorageKey';
     public static readonly EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY = 'extensionUnlockPasswordHash';
+    public static readonly EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY = 'extensionAutoUnlockPassword';
     public static readonly EXTENSION_SETUP_DONE_ACCESS_KEY = 'extensionSetupDone';
 
     public static async unlock(password: string, isFrontendCall = false) {
@@ -24,16 +25,17 @@ export default class ExtensionUnlockService {
             .then(async (extensionUnlockPasswordHash: string | undefined) => {
                 if (extensionUnlockPasswordHash === sha512(password)) {
                     // Verify that we can decrypt the storage key with this password
-                    const secureStorage = new SecureStorage();
-                    secureStorage.setPassword(password);
-                    const storageKey = await secureStorage.decryptStorageKey(password);
+                    const storageKey = await SecureStorage.decryptStorageKey(password);
 
                     if (!storageKey) {
                         logger.error("Failed to decrypt storage key during unlock");
                         return false;
                     }
 
-                    await CustomStorageService.getSessionStorage().set(this.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY, password);
+                    await CustomStorageService.getSessionStorage().set(
+                        this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
+                        await SecureStorage.exportStorageKeyBase64(storageKey)
+                    );
                     ExtensionBadgeService.updateAllTabsIcon(isFrontendCall);
                     this.notifyReloadContentScriptPicker();
                     await ConsoleLoggingService.refreshLogLevel().catch(() => {
@@ -45,12 +47,29 @@ export default class ExtensionUnlockService {
             });
     }
 
+    public static async setAutoUnlockExtensionPassword(password: string) {
+        await CustomStorageService.getUnsafeLocalStorage()
+            .set(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY, password);
+    }
+
+    public static async getAutoUnlockExtensionPassword(): Promise<string | undefined> {
+        return await CustomStorageService.getUnsafeLocalStorage()
+            .get<string>(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY);
+    }
+
+    public static async clearAutoUnlockExtensionPassword() {
+        await CustomStorageService.getUnsafeLocalStorage()
+            .remove(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY);
+    }
+
     /**
      * Locks the extension, as well as taking care about clearing decrypted cache within the background service worker.
+     * Once locked, a potential stored vault key for the auto-unlock feature is invalidated.
      * Should be called from the LockExtension MessageHandler.
      */
     public static async lock() {
         await CustomStorageService.clearSessionStorage();
+        await ExtensionUnlockService.clearAutoUnlockExtensionPassword();
         CustomStorageService.closeSecureStorage();
         PassmanClientService.invalidatePassmanClients();
         ExtensionBadgeService.displayLockIcons();
@@ -84,21 +103,30 @@ export default class ExtensionUnlockService {
      * Generates a new storage key if one doesn't exist.
      * @param password
      */
-    public static async setUpExtensionPassword(password: string): Promise<void> {
-        await CustomStorageService.getUnsafeLocalStorage()
-            .set(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY, sha512(password));
-
+    public static async setUpExtensionPassword(password: string, setAsAutoUnlockPassword = false): Promise<void> {
         // Generate and store encryption key if it doesn't exist
-        const hasKey = await SecureStorage.hasEncryptedStorageKey();
-        if (!hasKey) {
-            const storageKey = await SecureStorage.generateStorageKey();
-            const secureStorage = new SecureStorage();
-            secureStorage.setPassword(password);
-            const encryptedKeyData = await secureStorage.encryptStorageKey(storageKey, password);
+        let storageKey: CryptoKey | null;
+        if (await SecureStorage.hasEncryptedStorageKey()) {
+            storageKey = await SecureStorage.decryptStorageKey(password);
+            if (!storageKey) {
+                throw new Error("A storage key already exists but could not be decrypted with the given password");
+            }
+        } else {
+            storageKey = await SecureStorage.generateStorageKey();
+            const encryptedKeyData = await SecureStorage.encryptStorageKey(storageKey, password);
             await SecureStorage.storeEncryptedStorageKey(encryptedKeyData);
         }
 
-        await CustomStorageService.getSessionStorage().set(this.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY, password);
+        await CustomStorageService.getUnsafeLocalStorage()
+            .set(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY, sha512(password));
+
+        await CustomStorageService.getSessionStorage().set(
+            this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
+            await SecureStorage.exportStorageKeyBase64(storageKey)
+        );
+        if (setAsAutoUnlockPassword) {
+            await ExtensionUnlockService.setAutoUnlockExtensionPassword(password);
+        }
     }
 
     /**
@@ -122,9 +150,7 @@ export default class ExtensionUnlockService {
         }
 
         // Decrypt the storage key with old password
-        const secureStorage = new SecureStorage();
-        secureStorage.setPassword(oldPassword);
-        const storageKey = await secureStorage.decryptStorageKey(oldPassword);
+        const storageKey = await SecureStorage.decryptStorageKey(oldPassword);
 
         if (!storageKey) {
             logger.error("Failed to decrypt storage key with old password");
@@ -132,14 +158,21 @@ export default class ExtensionUnlockService {
         }
 
         // Re-encrypt the storage key with new password
-        secureStorage.setPassword(newPassword);
-        const encryptedKeyData = await secureStorage.encryptStorageKey(storageKey, newPassword);
+        const encryptedKeyData = await SecureStorage.encryptStorageKey(storageKey, newPassword);
         await SecureStorage.storeEncryptedStorageKey(encryptedKeyData);
 
-        // Update password hash and session storage
+        // Update password hash and session storage. The storage key itself is unchanged.
         await CustomStorageService.getUnsafeLocalStorage()
             .set(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY, sha512(newPassword));
-        await CustomStorageService.getSessionStorage().set(this.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY, newPassword);
+        await CustomStorageService.getSessionStorage().set(
+            this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
+            await SecureStorage.exportStorageKeyBase64(storageKey)
+        );
+
+        // Update auto-unlock password if it was set
+        if (await ExtensionUnlockService.getAutoUnlockExtensionPassword()) {
+            await ExtensionUnlockService.setAutoUnlockExtensionPassword(newPassword);
+        }
 
         // Clear cached key in secure storage
         CustomStorageService.closeSecureStorage();
@@ -169,14 +202,14 @@ export default class ExtensionUnlockService {
     }
 
     /**
-     * The extension is unlocked if the extension session storage contains an extension unlock password.
+     * The extension is unlocked if the extension session storage contains the storage key.
      * This is fine as it's in only extension-accessible memory, only written by the extension.
      */
     public static isUnlocked() {
         return CustomStorageService.getSessionStorage()
-            .get(this.EXTENSION_UNLOCK_PASSWORD_SESSION_ACCESS_KEY)
-            .then(async (extensionUnlockPassword: string | undefined) => {
-                return extensionUnlockPassword !== undefined && extensionUnlockPassword !== null;
+            .get(this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY)
+            .then(async (rawStorageKey: string | undefined) => {
+                return rawStorageKey !== undefined && rawStorageKey !== null;
             });
     }
 

--- a/src/services/ExtensionUnlockService.ts
+++ b/src/services/ExtensionUnlockService.ts
@@ -1,4 +1,3 @@
-import { sha512 } from "js-sha512";
 import CustomStorageService from "./CustomStorageService";
 import ExtensionSettingsService, { ExtensionSettingsOptions } from "./ExtensionSettingsService";
 import PassmanClientService from "./PassmanClientService";
@@ -15,61 +14,51 @@ import ConsoleLoggingService, { logger } from "./ConsoleLoggingService";
 
 export default class ExtensionUnlockService {
     public static readonly EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY = 'extensionStorageKey';
-    public static readonly EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY = 'extensionUnlockPasswordHash';
-    public static readonly EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY = 'extensionAutoUnlockPassword';
     public static readonly EXTENSION_SETUP_DONE_ACCESS_KEY = 'extensionSetupDone';
 
-    public static async unlock(password: string, isFrontendCall = false) {
-        return await this.isSetupDone() && await (CustomStorageService.getUnsafeLocalStorage()
-            .get(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY))
-            .then(async (extensionUnlockPasswordHash: string | undefined) => {
-                if (extensionUnlockPasswordHash === sha512(password)) {
-                    // Verify that we can decrypt the storage key with this password
-                    const storageKey = await SecureStorage.decryptStorageKey(password);
+    /**
+     * Unlock the extension with the extension unlock password.
+     * The password is only used to unwrap the storage key and is never persisted anywhere.
+     */
+    public static async unlock(password: string, isFrontendCall = false): Promise<boolean> {
+        if (!await this.isSetupDone()) {
+            return false;
+        }
 
-                    if (!storageKey) {
-                        logger.error("Failed to decrypt storage key during unlock");
-                        return false;
-                    }
+        // The AES-GCM authentication tag of the wrapped storage key verifies the password
+        const storageKey = await SecureStorage.decryptStorageKey(password);
 
-                    await CustomStorageService.getSessionStorage().set(
-                        this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
-                        await SecureStorage.exportStorageKeyBase64(storageKey)
-                    );
-                    ExtensionBadgeService.updateAllTabsIcon(isFrontendCall);
-                    this.notifyReloadContentScriptPicker();
-                    await ConsoleLoggingService.refreshLogLevel().catch(() => {
-                        // logging should not block unlock
-                    });
-                    return true;
-                }
-                return false;
-            });
+        if (!storageKey) {
+            logger.error("Failed to decrypt storage key during unlock");
+            return false;
+        }
+
+        await this.applyUnlockedStorageKey(storageKey, isFrontendCall);
+        return true;
     }
 
-    public static async setAutoUnlockExtensionPassword(password: string) {
-        await CustomStorageService.getUnsafeLocalStorage()
-            .set(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY, password);
-    }
-
-    public static async getAutoUnlockExtensionPassword(): Promise<string | undefined> {
-        return await CustomStorageService.getUnsafeLocalStorage()
-            .get<string>(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY);
-    }
-
-    public static async clearAutoUnlockExtensionPassword() {
-        await CustomStorageService.getUnsafeLocalStorage()
-            .remove(this.EXTENSION_AUTO_UNLOCK_PASSWORD_ACCESS_KEY);
+    /**
+     * Hand the decrypted storage key over to the running extension and reflect the unlocked state in the UI.
+     * Shared by the password based unlock, the initial setup and the auto-unlock.
+     */
+    public static async applyUnlockedStorageKey(storageKey: CryptoKey, isFrontendCall = false): Promise<void> {
+        await CustomStorageService.getSessionStorage().set(
+            this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
+            await SecureStorage.exportStorageKeyBase64(storageKey)
+        );
+        ExtensionBadgeService.updateAllTabsIcon(isFrontendCall);
+        this.notifyReloadContentScriptPicker();
+        await ConsoleLoggingService.refreshLogLevel().catch(() => {
+            // logging should not block unlock
+        });
     }
 
     /**
      * Locks the extension, as well as taking care about clearing decrypted cache within the background service worker.
-     * Once locked, a potential stored vault key for the auto-unlock feature is invalidated.
      * Should be called from the LockExtension MessageHandler.
      */
     public static async lock() {
         await CustomStorageService.clearSessionStorage();
-        await ExtensionUnlockService.clearAutoUnlockExtensionPassword();
         CustomStorageService.closeSecureStorage();
         PassmanClientService.invalidatePassmanClients();
         ExtensionBadgeService.displayLockIcons();
@@ -98,12 +87,13 @@ export default class ExtensionUnlockService {
     }
 
     /**
-     * Set or overwrite the hash to validate the extension unlock password against.
+     * Set the extension unlock password.
      * This also unlocks the extension already.
      * Generates a new storage key if one doesn't exist.
      * @param password
+     * @throws Error when a storage key exists that cannot be unwrapped with the given password
      */
-    public static async setUpExtensionPassword(password: string, setAsAutoUnlockPassword = false): Promise<void> {
+    public static async setUpExtensionPassword(password: string): Promise<void> {
         // Generate and store encryption key if it doesn't exist
         let storageKey: CryptoKey | null;
         if (await SecureStorage.hasEncryptedStorageKey()) {
@@ -117,16 +107,7 @@ export default class ExtensionUnlockService {
             await SecureStorage.storeEncryptedStorageKey(encryptedKeyData);
         }
 
-        await CustomStorageService.getUnsafeLocalStorage()
-            .set(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY, sha512(password));
-
-        await CustomStorageService.getSessionStorage().set(
-            this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
-            await SecureStorage.exportStorageKeyBase64(storageKey)
-        );
-        if (setAsAutoUnlockPassword) {
-            await ExtensionUnlockService.setAutoUnlockExtensionPassword(password);
-        }
+        await this.applyUnlockedStorageKey(storageKey);
     }
 
     /**
@@ -141,15 +122,7 @@ export default class ExtensionUnlockService {
             return false;
         }
 
-        // Verify old password
-        const oldPasswordHash = await CustomStorageService.getUnsafeLocalStorage()
-            .get<string>(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY);
-
-        if (!oldPasswordHash || oldPasswordHash !== sha512(oldPassword)) {
-            return false;
-        }
-
-        // Decrypt the storage key with old password
+        // Decrypt the storage key with old password, which verifies it at the same time
         const storageKey = await SecureStorage.decryptStorageKey(oldPassword);
 
         if (!storageKey) {
@@ -161,18 +134,11 @@ export default class ExtensionUnlockService {
         const encryptedKeyData = await SecureStorage.encryptStorageKey(storageKey, newPassword);
         await SecureStorage.storeEncryptedStorageKey(encryptedKeyData);
 
-        // Update password hash and session storage. The storage key itself is unchanged.
-        await CustomStorageService.getUnsafeLocalStorage()
-            .set(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY, sha512(newPassword));
+        // The storage key itself is unchanged, so nothing but the session state has to be refreshed
         await CustomStorageService.getSessionStorage().set(
             this.EXTENSION_STORAGE_KEY_SESSION_ACCESS_KEY,
             await SecureStorage.exportStorageKeyBase64(storageKey)
         );
-
-        // Update auto-unlock password if it was set
-        if (await ExtensionUnlockService.getAutoUnlockExtensionPassword()) {
-            await ExtensionUnlockService.setAutoUnlockExtensionPassword(newPassword);
-        }
 
         // Clear cached key in secure storage
         CustomStorageService.closeSecureStorage();
@@ -186,11 +152,7 @@ export default class ExtensionUnlockService {
     }
 
     public static isExtensionPasswordSetUp() {
-        return CustomStorageService.getUnsafeLocalStorage()
-            .get(this.EXTENSION_UNLOCK_PASSWORD_HASH_ACCESS_KEY)
-            .then(async (extensionUnlockPasswordHash: string | undefined) => {
-                return extensionUnlockPasswordHash !== undefined && extensionUnlockPasswordHash !== null;
-            });
+        return SecureStorage.hasEncryptedStorageKey();
     }
 
     public static isSetupDone() {

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -24,8 +24,9 @@
         type OfflineCacheStorageBackend,
     } from "~/services/OfflineCacheStorageService";
     import { sendMessage } from "@/entrypoints/background/messaging";
-    import CustomStorageService from "~/services/CustomStorageService";
     import ChangeUnlockPassword from "~/spa_components/Settings/ChangeUnlockPassword.svelte";
+    import ExtensionAutoUnlockService from "~/services/ExtensionAutoUnlockService";
+    import type { AutoUnlockKeyStorageBackend } from "@/lib/auto-unlock-key-store";
     import type { IndexedDbModelStoreSizeEstimate } from "@binsky/passman-client-ts/lib/Service/IndexedDbModelStore";
     import {
         DEFAULT_DOORHANGER_GRAVITY,
@@ -145,6 +146,9 @@
     let clearingOfflineCache = $state(false);
     let offlineCacheEffective = $state<OfflineCacheStorageBackend>(OfflineCacheStorageService.DEFAULT_BACKEND);
     let offlineCacheForcedFallback = $state(false);
+    let autoUnlockEnabled = $state(false);
+    let autoUnlockUserWantsEnabled = $state(false);
+    let autoUnlockBackend = $state<AutoUnlockKeyStorageBackend>("indexeddb");
 
     const syncOfflineCacheStatus = () => {
         offlineCacheEffective = OfflineCacheStorageService.getEffective();
@@ -227,6 +231,35 @@
         return true;
     };
 
+    const applyAutoUnlockChange = async () => {
+        if (autoUnlockUserWantsEnabled === autoUnlockEnabled) {
+            return true;
+        }
+
+        const wantEnabled = autoUnlockUserWantsEnabled;
+        try {
+            if (wantEnabled) {
+                const enabled = await ExtensionAutoUnlockService.enable();
+                if (!enabled) {
+                    autoUnlockEnabled = false;
+                    NotyService.notyError(i18n.getMessage("auto_unlock_enable_failed"));
+                    return false;
+                }
+                autoUnlockBackend = await ExtensionAutoUnlockService.getStorageBackend();
+            } else {
+                await ExtensionAutoUnlockService.disable();
+            }
+            return true;
+        } catch (e) {
+            logger.error(e);
+            autoUnlockEnabled = !wantEnabled;
+            NotyService.notyError(
+                i18n.getMessage(wantEnabled ? "auto_unlock_enable_failed" : "auto_unlock_disable_failed")
+            );
+        }
+        return false;
+    };
+
     const save = async () => {
         lockSaveButton = true;
         logger.log("extendedSettings", extendedSettings);
@@ -240,7 +273,8 @@
             const offlineCacheApplied = await applyOfflineCacheStorageBackend(
                 offlineCacheBackendSelectValue.value as OfflineCacheStorageBackend
             );
-            if (offlineCacheApplied) {
+            const autoUnlockApplied = await applyAutoUnlockChange();
+            if (offlineCacheApplied && autoUnlockApplied) {
                 NotyService.notySuccess(i18n.getMessage("settings_updated_successfully"));
             }
         } catch (e) {
@@ -314,6 +348,10 @@
                     // Reflect forced fallback in the select if settings were auto-updated
                     setOfflineCacheBackendSelect(OfflineCacheStorageService.getPreferred());
                     await refreshOfflineCacheSize();
+
+                    autoUnlockEnabled = await ExtensionAutoUnlockService.isEnabled();
+                    autoUnlockUserWantsEnabled = autoUnlockEnabled;
+                    autoUnlockBackend = await ExtensionAutoUnlockService.getStorageBackend();
                 } else {
                     push('/unlock');
                 }
@@ -332,6 +370,23 @@
         <h2 class="text-xl font-semibold">{i18n.getMessage('extended_settings')}</h2>
 
         <ChangeUnlockPassword/>
+
+        <CustomCheckboxField
+            bind:value={autoUnlockUserWantsEnabled}
+            id="enableAutoUnlock"
+            label={i18n.getMessage('enable_auto_unlock')}
+        />
+        {#if autoUnlockUserWantsEnabled }
+            <div class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100 ms-4">
+                <p>{i18n.getMessage('enable_auto_unlock_description')}</p>
+            </div>
+        {/if}
+        <p class="description-text">{i18n.getMessage('enable_auto_unlock_lock_note')}</p>
+        {#if autoUnlockBackend === 'local'}
+            <div class="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100">
+                <p>{i18n.getMessage('enable_auto_unlock_local_fallback_notice')}</p>
+            </div>
+        {/if}
 
         <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.ignoreProtocol]}
                                 id="ignoreProtocol"


### PR DESCRIPTION
- implement auto-unlock feature based on a dedicated AES key for SecureStorage decryption, instead of relying on storing the plain password (like to legacy extension did in v2)
- refactor ExtensionUnlockService: no longer store the user extension password nor its hash anywhere
- refactor SecureStorage implementation to rely on a new encryption-key, instead of the extension unlock password

closes #371