### PR TITLE
Improve settings and credential sections menu styling

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -231,17 +231,21 @@
     "message": "Refresh timer [s]",
     "description": "Password"
   },
+  "website_credential_filter_options": {
+    "message": "Website credential filter options",
+    "description": "Label for the settings section about modifying default credential matching behavior for all websites"
+  },
   "ignore_protocol": {
     "message": "Ignore protocol for site matching",
-    "description": "Ignore protocol for site matching"
+    "description": "Checkbox label for ignoring the url protocol when matching credentials to websites"
   },
   "ignore_subdomain": {
     "message": "Ignore subdomain for site matching",
-    "description": "Password"
+    "description": "Checkbox label for ignoring the url subdomain when matching credentials to websites"
   },
   "ignore_port": {
     "message": "Ignore port for site matching",
-    "description": "Ignore port for site matching"
+    "description": "Checkbox label for ignoring the url port when matching credentials to websites"
   },
   "http_warning": {
     "message": "You are using HTTP! Login credentials will be send in plain text. Your Passman credentials are still encrypted.",
@@ -249,11 +253,11 @@
   },
   "ignore_path": {
     "message": "Ignore path for site matching",
-    "description": "Ignore path for site matching"
+    "description": "Checkbox label for ignoring the url path when matching credentials to websites"
   },
   "ignore_page": {
     "message": "Ignore this page when suggesting credentials",
-    "description": "Checkbox label for ignoring a specific page"
+    "description": "Checkbox label for ignoring a specific page when suggesting credentials in the password picker"
   },
   "enable_autofill": {
     "message": "Enable form auto fill (for a single matching credential)",

--- a/src/entrypoints/options/App.svelte
+++ b/src/entrypoints/options/App.svelte
@@ -3,7 +3,7 @@
   import { onMount } from "svelte";
   import { routes } from "@/popupRoutes";
   // @ts-expect-error
-  import Router, { push } from "@/Router.svelte";
+  import Router, { push, location } from "@/Router.svelte";
   import extensionUnlockStateStore, { ExtensionUnlockState } from "@/stores/extensionUnlockStateStore";
   import BottomNavBar from "@/spa_partials/BottomNavBar.svelte";
   import Toaster from "@/spa_partials/Toaster.svelte";
@@ -28,7 +28,9 @@
           break;
         case ExtensionUnlockState.UNLOCKED:
           // correct unlock password already in session
-          push('/home');
+          if ($location === null || $location === '' || $location === '/') {
+            push('/home');
+          }
           break;
         default:
           logger.error(i18n.getMessage('unknown_error_checking_lock_state'));

--- a/src/spa_components/CredentialAdd.svelte
+++ b/src/spa_components/CredentialAdd.svelte
@@ -19,6 +19,7 @@
     import EditFiles from "~/spa_partials/CredentialEditSections/EditFiles.svelte";
     import { i18n } from "~/lib/i18n";
     import { logger } from "~/services/ConsoleLoggingService";
+    import FlexibleSectionsButtonLayout from "@/spa_partials/CredentialEditSections/FlexibleSectionsButtonLayout.svelte";
 
     let pageIsLoading = true;
     let lockSaveButton = false;
@@ -107,35 +108,17 @@
         {#if pageIsLoading}
             <Loading/>
         {:else}
-            <div class="w-full flex flex-nowrap items-center justify-center space-x-4 border-b p-2 bg-white">
+            <div class="w-full flex items-center gap-2 border-b p-2 bg-white">
                 <OnClickButton callback={saveCredential} title="{i18n.getMessage('save')}"
-                               bind:disabled="{lockSaveButton}">
+                               additionalClasses="shrink-0"
+                               disabled={lockSaveButton}>
                     {#if lockSaveButton}
                         <Icon data={refresh} scale={1.3} spin="{true}"/>
                     {:else}
                         <Icon data={save} scale={1.3}/>
                     {/if}
                 </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.GENERAL)} title="{i18n.getMessage('general')}"
-                               additionalClasses=""
-                               disabled={!credential}>
-                    <span>{i18n.getMessage('general')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.FILES)}
-                                title="{i18n.getMessage('files')}" additionalClasses=""
-                                disabled={!credential}>
-                    <span>{i18n.getMessage('files')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.CUSTOM_FIELDS)}
-                               title="{i18n.getMessage('custom_fields')}" additionalClasses=""
-                               disabled={!credential}>
-                    <span>{i18n.getMessage('custom_fields')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.OTP)}
-                                title="{i18n.getMessage('one_time_password')}" additionalClasses=""
-                                disabled={!credential}>
-                    <span>{i18n.getMessage('one_time_password')}</span>
-                </OnClickButton>
+                <FlexibleSectionsButtonLayout openSection={openSection} credential={credential} />
             </div>
             <div class="flex flex-col p-5">
                 {#if credentialData}

--- a/src/spa_components/CredentialEdit.svelte
+++ b/src/spa_components/CredentialEdit.svelte
@@ -19,6 +19,7 @@
     import EditFiles from "~/spa_partials/CredentialEditSections/EditFiles.svelte";
     import { i18n } from "~/lib/i18n";
     import { logger } from "~/services/ConsoleLoggingService";
+    import FlexibleSectionsButtonLayout from "@/spa_partials/CredentialEditSections/FlexibleSectionsButtonLayout.svelte";
 
     export let params: { guid?: string } = {};
     let pageIsLoading = true;
@@ -125,35 +126,17 @@
         {#if pageIsLoading}
             <Loading/>
         {:else}
-            <div class="w-full flex flex-nowrap items-center justify-center space-x-4 border-b p-2 bg-white">
+            <div class="w-full flex items-center gap-2 border-b p-2 bg-white">
                 <OnClickButton callback={saveCredential} title="{i18n.getMessage('save')}"
-                               bind:disabled="{lockSaveButton}">
+                               additionalClasses="shrink-0"
+                               disabled={lockSaveButton}>
                     {#if lockSaveButton}
                         <Icon data={refresh} scale={1.3} spin="{true}"/>
                     {:else}
                         <Icon data={save} scale={1.3}/>
                     {/if}
                 </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.GENERAL)} title="{i18n.getMessage('general')}"
-                               additionalClasses=""
-                               disabled={!credential}>
-                    <span>{i18n.getMessage('general')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.FILES)}
-                                title="{i18n.getMessage('files')}" additionalClasses=""
-                                disabled={!credential}>
-                    <span>{i18n.getMessage('files')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.CUSTOM_FIELDS)}
-                               title="{i18n.getMessage('custom_fields')}" additionalClasses=""
-                               disabled={!credential}>
-                    <span>{i18n.getMessage('custom_fields')}</span>
-                </OnClickButton>
-                <OnClickButton callback={() => openSection(CREDENTIAL_EDIT_SECTIONS.OTP)}
-                                title="{i18n.getMessage('one_time_password')}" additionalClasses=""
-                                disabled={!credential}>
-                    <span>{i18n.getMessage('one_time_password')}</span>
-                </OnClickButton>
+                <FlexibleSectionsButtonLayout openSection={openSection} credential={credential} />
             </div>
             <div class="flex flex-col p-5">
                 {#if credentialData}

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Card from "~/spa_partials/Card.svelte";
     import OnClickButton from "~/spa_partials/InteractionElements/OnClickButton.svelte";
-    import refresh from "svelte-awesome/icons/refresh";
+    import { refresh, save as saveIcon } from "svelte-awesome/icons";
     import Icon from "svelte-awesome/components/Icon.svelte";
     import { onMount } from "svelte";
     import ExtensionUnlockService from "~/services/ExtensionUnlockService";
@@ -37,6 +37,7 @@
         EXTENSION_LOG_LEVELS,
         type ExtensionLogLevel,
     } from "~/lib/extensionLogLevel";
+    import FloatingActionButton from "@/spa_partials/InteractionElements/FloatingActionButton.svelte";
 
     type ExtendedSettingsForm = Pick<ExtensionSettings,
         | ExtensionSettingsOptions.ignoreProtocol
@@ -150,6 +151,30 @@
     let autoUnlockUserWantsEnabled = $state(false);
     let autoUnlockBackend = $state<AutoUnlockKeyStorageBackend>("indexeddb");
 
+    type SavedFormState = {
+        settings: ExtendedSettingsForm;
+        autoUnlockEnabled: boolean;
+    };
+    let savedFormState = $state<SavedFormState | null>(null);
+
+    const settingsAreEqual = (a: ExtendedSettingsForm, b: ExtendedSettingsForm) => {
+        return JSON.stringify(a) === JSON.stringify(b);
+    };
+
+    const captureSavedFormState = () => {
+        savedFormState = {
+            settings: { ...extendedSettings },
+            autoUnlockEnabled,
+        };
+    };
+
+    const hasPendingChanges = $derived(
+        savedFormState !== null && (
+            !settingsAreEqual(extendedSettings, savedFormState.settings) ||
+            autoUnlockUserWantsEnabled !== savedFormState.autoUnlockEnabled
+        )
+    );
+
     const syncOfflineCacheStatus = () => {
         offlineCacheEffective = OfflineCacheStorageService.getEffective();
         offlineCacheForcedFallback = OfflineCacheStorageService.isForcedFallback();
@@ -245,9 +270,11 @@
                     NotyService.notyError(i18n.getMessage("auto_unlock_enable_failed"));
                     return false;
                 }
+                autoUnlockEnabled = true;
                 autoUnlockBackend = await ExtensionAutoUnlockService.getStorageBackend();
             } else {
                 await ExtensionAutoUnlockService.disable();
+                autoUnlockEnabled = false;
             }
             return true;
         } catch (e) {
@@ -261,6 +288,9 @@
     };
 
     const save = async () => {
+        if (!hasPendingChanges || lockSaveButton) {
+            return;
+        }
         lockSaveButton = true;
         logger.log("extendedSettings", extendedSettings);
         try {
@@ -276,6 +306,7 @@
             const autoUnlockApplied = await applyAutoUnlockChange();
             if (offlineCacheApplied && autoUnlockApplied) {
                 NotyService.notySuccess(i18n.getMessage("settings_updated_successfully"));
+                captureSavedFormState();
             }
         } catch (e) {
             logger.error(e);
@@ -352,6 +383,9 @@
                     autoUnlockEnabled = await ExtensionAutoUnlockService.isEnabled();
                     autoUnlockUserWantsEnabled = autoUnlockEnabled;
                     autoUnlockBackend = await ExtensionAutoUnlockService.getStorageBackend();
+
+                    // capture the initial settings state to detect changes afterwards
+                    captureSavedFormState();
                 } else {
                     push('/unlock');
                 }
@@ -585,13 +619,14 @@
         </OnClickButton>
     </Card>
 
-    <OnClickButton callback={save}>
-        {#if lockSaveButton}
-            <Icon data={refresh} scale={1.3} spin={true}/>
-        {:else}
-            {i18n.getMessage('save_settings')}
-        {/if}
-    </OnClickButton>
+    <FloatingActionButton
+        icon={saveIcon}
+        label={i18n.getMessage('save_settings')}
+        title={i18n.getMessage('save_settings')}
+        ariaLabel={i18n.getMessage('save_settings')}
+        onSave={save}
+        disabled={!hasPendingChanges || lockSaveButton}
+    />
 {/if}
 
 <div class="mt-4">

--- a/src/spa_components/Settings/ExtendedSettings.svelte
+++ b/src/spa_components/Settings/ExtendedSettings.svelte
@@ -388,6 +388,22 @@
             </div>
         {/if}
 
+        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.autofillEnabled]}
+                id="enable_autofill"
+                label={i18n.getMessage('enable_autofill')}/>
+        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enableEmailAsUsernameFallbackFilling]}
+                id="enableEmailAsUsernameFallbackFilling"
+                label={i18n.getMessage('enable_email_as_username_fallback_filling')}/>
+        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enableDoorhanger]}
+                id="enableDoorhanger"
+                label={i18n.getMessage('enable_doorhanger')}/>
+        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enablePasswordPicker]}
+                id="enablePasswordPicker"
+                label={i18n.getMessage('enable_password_picker')}/>
+
+        <hr class="my-4 border-gray-200"/>
+
+        <h3 class="text-lg font-semibold">{i18n.getMessage('website_credential_filter_options')}</h3>
         <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.ignoreProtocol]}
                                 id="ignoreProtocol"
                                 label={i18n.getMessage('ignore_protocol')}/>
@@ -400,18 +416,6 @@
         <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.ignorePort]}
                                 id="ignorePort"
                                 label={i18n.getMessage('ignore_port')}/>
-        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.autofillEnabled]}
-                                id="enable_autofill"
-                                label={i18n.getMessage('enable_autofill')}/>
-        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enableEmailAsUsernameFallbackFilling]}
-                                id="enableEmailAsUsernameFallbackFilling"
-                                label={i18n.getMessage('enable_email_as_username_fallback_filling')}/>
-        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enableDoorhanger]}
-                                id="enableDoorhanger"
-                                label={i18n.getMessage('enable_doorhanger')}/>
-        <CustomCheckboxField bind:value={extendedSettings[ExtensionSettingsOptions.enablePasswordPicker]}
-                                id="enablePasswordPicker"
-                                label={i18n.getMessage('enable_password_picker')}/>
         
         <hr class="my-4 border-gray-200"/>
 

--- a/src/spa_partials/CredentialEditSections/EditCustomFields.svelte
+++ b/src/spa_partials/CredentialEditSections/EditCustomFields.svelte
@@ -4,11 +4,8 @@
         CustomFieldInterface
     } from "@binsky/passman-client-ts/lib/Interfaces/Credential/CustomFieldInterface";
     import Credential from "@binsky/passman-client-ts/lib/Model/Credential";
-    import trashO from "svelte-awesome/icons/trashO";
     import InPlaceEdit from "../FormElements/InPlaceEdit.svelte";
     import Icon from "svelte-awesome/components/Icon.svelte";
-    import refresh from "svelte-awesome/icons/refresh";
-    import plus from "svelte-awesome/icons/plus";
     import CustomInputField from "../FormElements/CustomInputField.svelte";
     import OnClickButton from "../InteractionElements/OnClickButton.svelte";
     import type { FileInterface } from "@binsky/passman-client-ts/lib/Interfaces/File/FileInterface";
@@ -17,6 +14,7 @@
     import Utils from "~/lib/Utils";
     import { i18n } from "~/lib/i18n";
     import { logger } from "~/services/ConsoleLoggingService";
+    import { externalLink, plus, refresh, trashO } from "svelte-awesome/icons";
 
     export let credentialData: DecryptedCredentialInterface;
     export let credential: Credential | null;  // only used for file encryption and upload
@@ -132,6 +130,12 @@
         credentialData.custom_fields.splice(pos, 1);
         customFieldReactivityCounter++;
     }
+
+    const openSameOptionsPage = () => {
+        const url = '/options.html' + window.location.hash;
+        // @ts-ignore
+        window.open(browser.runtime.getURL(url), '_blank');
+    }
 </script>
 
 {#if credentialData && credential}
@@ -192,6 +196,11 @@
                 <p class="text-sm text-gray-500">
                     {i18n.getMessage('error_file_upload_popup_2')}
                 </p>
+                <OnClickButton callback={openSameOptionsPage} title="{i18n.getMessage('open_options_page')}" small={true}
+                        additionalClasses="shrink-0"
+                        disabled={!credential}>
+                    <Icon data={externalLink} scale={1.3}/>
+                </OnClickButton>
             </div>
         {:else}
             <div class="pr-2">

--- a/src/spa_partials/CredentialEditSections/EditFiles.svelte
+++ b/src/spa_partials/CredentialEditSections/EditFiles.svelte
@@ -5,7 +5,6 @@
     import Credential from "@binsky/passman-client-ts/lib/Model/Credential";
     import type { FileInterface } from "@binsky/passman-client-ts/lib/Interfaces/File/FileInterface";
     import NotyService from "~/services/frontend/NotyService";
-    import trashO from "svelte-awesome/icons/trashO";
     import Icon from "svelte-awesome/components/Icon.svelte";
     import Time from "svelte-time";
     import { CustomMathsService } from "@binsky/passman-client-ts/lib/Service/CustomMathsService";
@@ -13,6 +12,8 @@
     import Utils from "~/lib/Utils";
     import { i18n } from "~/lib/i18n";
     import { logger } from "~/services/ConsoleLoggingService";
+    import { externalLink, trashO } from "svelte-awesome/icons";
+    import OnClickButton from "../InteractionElements/OnClickButton.svelte";
 
     export let credentialData: DecryptedCredentialInterface;
     export let credential: Credential | null;  // only used for file encryption and upload
@@ -111,6 +112,12 @@
             NotyService.notyError(i18n.getMessage("files_deletion_failed"));
         }
     }
+
+    const openSameOptionsPage = () => {
+        const url = '/options.html' + window.location.hash;
+        // @ts-ignore
+        window.open(browser.runtime.getURL(url), '_blank');
+    }
 </script>
 
 {#if credentialData}
@@ -123,6 +130,11 @@
                 <p class="text-sm text-gray-500">
                     {i18n.getMessage('error_file_upload_popup_2')}
                 </p>
+                <OnClickButton callback={openSameOptionsPage} title="{i18n.getMessage('open_options_page')}" small={true}
+                        additionalClasses="shrink-0"
+                        disabled={!credential}>
+                    <Icon data={externalLink} scale={1.3}/>
+                </OnClickButton>
             </div>
         {:else}
             <div class="flex flex-col items-center justify-center w-full">

--- a/src/spa_partials/CredentialEditSections/EditFiles.svelte
+++ b/src/spa_partials/CredentialEditSections/EditFiles.svelte
@@ -139,19 +139,19 @@
         {:else}
             <div class="flex flex-col items-center justify-center w-full">
                 <label for="file-upload"
-                    class="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100 dark:border-gray-600 dark:bg-neutral dark:hover:border-gray-500 dark:hover:bg-neutral/80"
+                    class="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 hover:bg-gray-100"
                     on:dragenter={handleDragEnter}
                     on:dragover={handleDragOver}
                     on:dragleave={handleDragLeave}
                     on:drop={handleDrop}>
                     <div class="flex flex-col items-center justify-center pt-5 pb-6">
-                        <svg class="w-8 h-8 mb-4 text-gray-500 dark:text-gray-400" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 16">
+                        <svg class="w-8 h-8 mb-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 16">
                             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 13h3a3 3 0 0 0 0-6h-.025A5.56 5.56 0 0 0 16 6.5 5.5 5.5 0 0 0 5.207 5.021C5.137 5.017 5.071 5 5 5a4 4 0 0 0 0 8h2.167M10 15V6m0 0L8 8m2-2 2 2"/>
                         </svg>
-                        <p class="mb-2 text-sm text-gray-500 dark:text-gray-400">
+                        <p class="mb-2 text-sm text-gray-500">
                             {@html i18n.getMessage('files_upload_box_text', ['<span class="font-semibold">', '</span>'])}
                         </p>
-                        <p class="text-xs text-gray-500 dark:text-gray-400">
+                        <p class="text-xs text-gray-500">
                             {i18n.getMessage('files_any_type_info')}
                         </p>
                     </div>
@@ -161,7 +161,7 @@
                 {#if isUploading}
                     <div class="w-full mt-4 space-y-2">
                         <div class="flex justify-center">
-                            <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600 dark:border-blue-400"></div>
+                            <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
                         </div>
                     </div>
                 {/if}
@@ -169,8 +169,8 @@
         {/if}
 
         <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
-            <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-                <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-neutral dark:text-gray-400">
+            <table class="w-full text-sm text-left text-gray-500">
+                <thead class="text-xs text-gray-700 uppercase bg-gray-50">
                     <tr>
                         <th scope="col" class="px-6 py-3 w-5/12">{i18n.getMessage("files_header_name")}</th>
                         <th scope="col" class="px-6 py-3 w-3/12 whitespace-nowrap">{i18n.getMessage("files_header_created")}</th>
@@ -181,8 +181,8 @@
                 <tbody>
                     {#key isUploading}
                         {#each credentialData.files as file (file.file_id)}
-                            <tr class="bg-white border-b dark:bg-neutral dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-neutral/80">
-                                <td class="px-3 py-2 font-medium text-gray-900 dark:text-white">
+                            <tr class="bg-white border-b hover:bg-gray-50">
+                                <td class="px-3 py-2 font-medium text-gray-900">
                                     <InPlaceEdit bind:value={file.filename}/>
                                 </td>
                                 <td class="px-3 py-2">
@@ -194,7 +194,7 @@
                                 <td class="px-3 py-2 text-right">
                                     <button on:click={() => deleteFile(file)}
                                             title="{i18n.getMessage('delete')}"
-                                            class="font-medium text-red-600 dark:text-red-500 hover:underline">
+                                            class="font-medium text-red-600 hover:underline cursor-pointer">
                                         <Icon data={trashO} scale={1.0}/>
                                     </button>
                                 </td>

--- a/src/spa_partials/CredentialEditSections/FlexibleSectionsButtonLayout.svelte
+++ b/src/spa_partials/CredentialEditSections/FlexibleSectionsButtonLayout.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+    import { i18n } from "~/lib/i18n";
+    import OnClickButton from "../InteractionElements/OnClickButton.svelte";
+    import { CREDENTIAL_EDIT_SECTIONS } from "~/lib/Utils";
+    import type Credential from "@binsky/passman-client-ts/lib/Model/Credential";
+
+    type SectionButton = {
+        type: CREDENTIAL_EDIT_SECTIONS,
+        label: string
+    }
+
+    const sectionButtons: SectionButton[] = [
+        { type: CREDENTIAL_EDIT_SECTIONS.GENERAL, label: i18n.getMessage('general') },
+        { type: CREDENTIAL_EDIT_SECTIONS.FILES, label: i18n.getMessage('files') },
+        { type: CREDENTIAL_EDIT_SECTIONS.CUSTOM_FIELDS, label: i18n.getMessage('custom_fields') },
+        { type: CREDENTIAL_EDIT_SECTIONS.OTP, label: i18n.getMessage('one_time_password') }
+    ]
+
+    let { 
+        openSection,
+        credential
+    }: { 
+        openSection: (section: CREDENTIAL_EDIT_SECTIONS) => void,
+        credential: Credential | null
+    } = $props();
+
+    let wrapSectionButtons = $state(false);
+
+    /**
+     * Prefer a single row while labels fit; otherwise use a symmetric 2x2 grid.
+     * Intrinsic widths are measured off-layout so wrapped mode cannot skew the decision.
+     */
+     const sectionButtonsLayout = (node: HTMLDivElement) => {
+        const gapPx = 8; // gap-2
+        const labels = () => sectionButtons.map(section => section.label);
+
+        const update = () => {
+            const availableWidth = node.clientWidth;
+            if (availableWidth <= 0) {
+                return;
+            }
+
+            const measure = document.createElement('button');
+            measure.type = 'button';
+            measure.className = 'border border-gray-300 font-medium rounded-lg text-sm px-3 py-2 text-center';
+            measure.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;white-space:nowrap;width:max-content;height:auto;';
+            node.appendChild(measure);
+
+            let neededWidth = 0;
+            labels().forEach((label, index) => {
+                measure.textContent = label;
+                neededWidth += measure.getBoundingClientRect().width;
+                if (index > 0) {
+                    neededWidth += gapPx;
+                }
+            });
+            measure.remove();
+
+            const shouldWrap = neededWidth > availableWidth + 0.5;
+            if (shouldWrap !== wrapSectionButtons) {
+                wrapSectionButtons = shouldWrap;
+            }
+        };
+
+        const resizeObserver = new ResizeObserver(() => {
+            requestAnimationFrame(update);
+        });
+        resizeObserver.observe(node);
+        update();
+
+        return {
+            destroy() {
+                resizeObserver.disconnect();
+            }
+        };
+    };
+
+    const sectionButtonClasses = () =>
+        wrapSectionButtons
+            ? '!w-full h-full min-w-0 max-w-full overflow-hidden whitespace-normal break-words p-1 smaller-button-line-height'
+            : 'shrink-0 max-w-full overflow-hidden whitespace-nowrap';
+</script>
+
+<div class="min-w-0 flex-1 h-[stretch]" use:sectionButtonsLayout>
+    <div class="{wrapSectionButtons ? 'grid grid-cols-2 grid-rows-2 gap-2' : 'flex flex-nowrap items-center justify-around h-[stretch]'}">
+        {#each sectionButtons as section (section.type)}
+            <OnClickButton  
+                callback={() => openSection(section.type)}
+                title={section.label}
+                additionalClasses={sectionButtonClasses()}
+                disabled={!credential}
+                noPadding={wrapSectionButtons}
+            >
+                <span class="block max-w-full [overflow-wrap:anywhere] button-label-auto-shrink">
+                    {section.label}
+                </span>
+            </OnClickButton>
+        {/each}
+    </div>
+    <style>
+        /* 
+        This class allows the text to shrink if it exceeds the button width.
+        It uses CSS clamp to ensure a readable minimum size.
+        */
+        .button-label-auto-shrink {
+            display: block;
+            width: 100%;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .smaller-button-line-height .button-label-auto-shrink {
+            line-height: 1.2;
+        }
+    </style>
+</div>

--- a/src/spa_partials/InteractionElements/FloatingActionButton.svelte
+++ b/src/spa_partials/InteractionElements/FloatingActionButton.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+    import Icon, { type IconData } from "svelte-awesome/components/Icon.svelte";
+    import refresh from "svelte-awesome/icons/refresh";
+
+    let {
+        title = $bindable(''),
+        label = $bindable(''),
+        ariaLabel = $bindable(''),
+        disabled = $bindable(false),
+        icon = $bindable<IconData>(),
+        onSave = $bindable(async () => {}),
+    } = $props();
+
+    let isSaving = $state(false);
+
+    const save = async () => {
+        isSaving = true;
+        try {
+            await onSave();
+        } catch (error) {
+            // ignore errors, just prevent the button from being stuck in the saving state
+        } finally {
+            isSaving = false;
+        }
+    };
+</script>
+
+<div class="save-fab-anchor">
+    <button
+        type="button"
+        class="save-fab"
+        class:is-saving={isSaving}
+        class:has-pending={!disabled}
+        title={title}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        onclick={(event) => {
+            event.preventDefault();
+            save();
+        }}
+    >
+        {#if isSaving}
+            <Icon data={refresh} scale={1.3} spin={true}/>
+        {:else}
+            <span class="save-fab-icon" aria-hidden="true">
+                <Icon data={icon} scale={1.3}/>
+            </span>
+            <span class="save-fab-label">{label}</span>
+        {/if}
+    </button>
+</div>
+
+<style>
+    /* stick near the bottom of the scrollport while this section is in view */
+    .save-fab-anchor {
+        position: sticky;
+        /* top: calc(100% - 4.75rem); */
+        bottom: 4.5rem;
+        z-index: 40;
+        display: flex;
+        justify-content: flex-end;
+        height: 0;
+        width: stretch;
+        padding-right: 0.2rem;
+        pointer-events: none;
+    }
+
+    .save-fab {
+        pointer-events: auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 3.5rem;
+        min-width: 3.5rem;
+        width: 3.5rem;
+        padding: 0 0.95rem;
+        overflow: hidden;
+        border: none;
+        border-radius: 9999px;
+        background: #9ca3af;
+        color: #fff;
+        box-shadow: none;
+        cursor: not-allowed;
+        opacity: 0.75;
+        transition:
+            width 0.28s ease,
+            max-width 0.28s ease,
+            background-color 0.2s ease,
+            box-shadow 0.2s ease,
+            opacity 0.2s ease;
+    }
+
+    .save-fab.has-pending,
+    .save-fab.is-saving {
+        background: var(--color-primary);
+        box-shadow: 0 4px 14px rgba(37, 99, 235, 0.35);
+        opacity: 1;
+        cursor: pointer;
+    }
+
+    .save-fab.is-saving {
+        cursor: wait;
+        pointer-events: none;
+    }
+
+    .save-fab.has-pending:hover:not(.is-saving) {
+        width: max-content;
+        max-width: 20rem;
+        box-shadow: 0 6px 18px rgba(37, 99, 235, 0.45);
+    }
+
+    .save-fab-icon,
+    .save-fab-label {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        transition:
+            max-width 0.28s ease,
+            opacity 0.2s ease,
+            margin 0.28s ease,
+            transform 0.2s ease;
+    }
+
+    .save-fab-icon {
+        max-width: 1.5rem;
+        opacity: 1;
+    }
+
+    .save-fab-label {
+        max-width: 0;
+        margin-left: 0;
+        overflow: hidden;
+        opacity: 0;
+        font-size: 0.875rem;
+        font-weight: 500;
+        transform: translateX(0.25rem);
+    }
+
+    .save-fab.has-pending:hover:not(.is-saving) .save-fab-icon {
+        max-width: 0;
+        opacity: 0;
+        overflow: hidden;
+        transform: scale(0.6);
+    }
+
+    .save-fab.has-pending:hover:not(.is-saving) .save-fab-label {
+        max-width: 16rem;
+        margin-left: 0;
+        opacity: 1;
+        transform: translateX(0);
+    }
+</style>

--- a/src/spa_partials/InteractionElements/OnClickButton.svelte
+++ b/src/spa_partials/InteractionElements/OnClickButton.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
-    export let callback = () => {
-        undefined;
-    };
-    export let additionalClasses = '';
-    export let tabindex: number | undefined = undefined;
-    export let title = '';
-    export let disabled = false;
 
-    export let small = false;
+    let {
+        callback = () => {},
+        additionalClasses = '',
+        tabindex = undefined,
+        title = '',
+        disabled = false,
+        small = false,
+        noPadding = false,
+    }: {
+        callback: () => void,
+        additionalClasses?: string,
+        tabindex?: number,
+        title?: string,
+        disabled?: boolean,
+        small?: boolean,
+        noPadding?: boolean
+    } = $props();
+    
+
+    let padding = $derived(noPadding ? '' : small ? 'px-2 py-1' : 'px-3 py-2');
 
     // Create a wrapper function that doesn't pass the callback into the button event
     const handleClick = (event: Event) => {
@@ -18,13 +30,11 @@
 
 <button
         {title}
-        on:click={handleClick}
+        onclick={handleClick}
         {disabled}
         {tabindex}
         class="text-primary-light-button-text border border-gray-300 hover:bg-base-200 hover:shadow-sm font-medium rounded-lg
-	text-sm dark:hover:bg-neutral cursor-pointer {small
-		? 'px-2 py-1'
-		: 'px-3 py-2'} text-center w-auto disabled:opacity-70 disabled:pointer-events-none {additionalClasses}"
+	        text-sm dark:hover:bg-neutral cursor-pointer {padding} text-center w-auto disabled:opacity-70 disabled:pointer-events-none {additionalClasses}"
 >
     <slot/>
 </button>


### PR DESCRIPTION
- credential sections menu now uses a grid styling if the buttons with translated labels wouldn't fit in a single row
- add website credential filter options section in extended settings
- use a new floating action button for save action in extended settings